### PR TITLE
Package Operations & Polish (Workflow 3/3)

### DIFF
--- a/.paw/work/craft-polish/WorkflowContext.md
+++ b/.paw/work/craft-polish/WorkflowContext.md
@@ -38,6 +38,6 @@ Additional Inputs: none
 
 ## Stage Progress
 
-- Current Stage: final-review
+- Current Stage: pr
 - Current Phase: none
-- Completed Stages: spec, code-research, planning, planning-review, implementation
+- Completed Stages: spec, code-research, planning, planning-review, implementation, final-review

--- a/.paw/work/craft-polish/WorkflowContext.md
+++ b/.paw/work/craft-polish/WorkflowContext.md
@@ -1,0 +1,43 @@
+# WorkflowContext
+
+Work Title: Craft Polish
+Work ID: craft-polish
+Base Branch: main
+Target Branch: feature/craft-polish
+Workflow Mode: full
+Review Strategy: local
+Review Policy: final-only
+Session Policy: continuous
+Final Agent Review: enabled
+Final Review Mode: society-of-thought
+Final Review Interactive: smart
+Final Review Models: none
+Final Review Specialists: all
+Final Review Interaction Mode: debate
+Final Review Specialist Models: none
+Final Review Perspectives: auto
+Final Review Perspective Cap: 2
+Plan Generation Mode: single-model
+Plan Generation Models: none
+Planning Docs Review: enabled
+Planning Review Mode: multi-model
+Planning Review Interactive: smart
+Planning Review Models: gpt-5.3-codex, gemini-3-pro-preview, claude-opus-4.6
+Planning Review Specialists: all
+Planning Review Interaction Mode: parallel
+Planning Review Specialist Models: none
+Planning Review Perspectives: auto
+Planning Review Perspective Cap: 2
+Custom Workflow Instructions: none
+Initial Prompt: Workflow 3 of 3 for craft (Agent Skills Package Manager). Package Operations & Polish — craft add <dep>, craft remove <dep>, npm-style UI (progress bars, dependency tree visualization), improved error messages with actionable suggestions, integration test suite, and README. See WorkShaping at .paw/work/WorkShaping.md for full context.
+Issue URL: none
+Remote: origin
+Artifact Lifecycle: commit-and-persist
+Artifact Paths: auto-derived
+Additional Inputs: none
+
+## Stage Progress
+
+- Current Stage: spec
+- Current Phase: none
+- Completed Stages: none

--- a/.paw/work/craft-polish/WorkflowContext.md
+++ b/.paw/work/craft-polish/WorkflowContext.md
@@ -38,6 +38,6 @@ Additional Inputs: none
 
 ## Stage Progress
 
-- Current Stage: implementation
-- Current Phase: 1
-- Completed Stages: spec, code-research, planning, planning-review
+- Current Stage: final-review
+- Current Phase: none
+- Completed Stages: spec, code-research, planning, planning-review, implementation

--- a/.paw/work/craft-polish/WorkflowContext.md
+++ b/.paw/work/craft-polish/WorkflowContext.md
@@ -38,6 +38,6 @@ Additional Inputs: none
 
 ## Stage Progress
 
-- Current Stage: spec
-- Current Phase: none
-- Completed Stages: none
+- Current Stage: implementation
+- Current Phase: 1
+- Completed Stages: spec, code-research, planning, planning-review

--- a/.paw/work/craft-polish/artifacts/CodeResearch.md
+++ b/.paw/work/craft-polish/artifacts/CodeResearch.md
@@ -1,0 +1,89 @@
+# CodeResearch: craft-polish
+
+## Codebase Snapshot
+
+**Total Go code:** ~7,500 lines across 13 internal packages, 28 test files.
+**External deps:** go-git v5.17.0, cobra v1.10.2, yaml.v3 v3.0.1.
+**Transitive:** golang.org/x/term v0.37.0 available (via go-git's SSH deps).
+
+## Key Integration Points
+
+### CLI Command Registration
+- **File:** `internal/cli/root.go:18-25`
+- Pattern: commands registered in `init()` via `rootCmd.AddCommand()`
+- New `addCmd` and `removeCmd` follow this pattern
+
+### Manifest Write (atomic)
+- **File:** `internal/cli/update.go:159-183` — `writeManifestAtomic()`
+- Pattern: write to `.tmp`, close, rename. Reusable for `craft add` and `craft remove`.
+
+### Pinfile Write (atomic)
+- **File:** `internal/cli/install.go:104-128` — `writePinfileAtomic()`
+- Same temp+rename pattern. Already shared between install and update.
+
+### Dependency Resolution
+- **File:** `internal/resolve/resolver.go:48-199` — `Resolve()`
+- `craft add` can use `Resolve()` for validation (resolve single dep to verify it exists)
+- `ResolveOptions.ForceResolve` forces re-resolution of specific deps
+
+### Agent Detection
+- **File:** `internal/agent/detect.go:48-88` — `Detect()`
+- Currently errors on multi-agent detection (line 85)
+- Must be changed to return all detected agents for interactive prompt
+
+### Install Target Resolution
+- **File:** `internal/cli/install.go:130-146` — `resolveInstallTarget()`
+- Calls `agent.Detect()` — needs modification for multi-agent flow
+
+### Skill File Collection
+- **File:** `internal/cli/install.go:148-206` — `collectSkillFiles()`
+- Used by both install and update. Needed by `craft remove` to identify orphaned files.
+
+### Error Display Pattern
+- **File:** `internal/cli/validate.go:33-38`
+- Pattern: `error: <msg>\n  fix: <suggestion>` on stderr
+- `validate.Error` struct has `.Suggestion` field
+
+### Output Pattern
+- All commands use `cmd.Println()` (stdout) and `cmd.PrintErrf()` (stderr)
+- No progress indicators, no colors, no tree display currently
+
+## TTY Detection
+
+`golang.org/x/term` available as transitive dep. Need to add as direct dep:
+```go
+import "golang.org/x/term"
+isTerminal := term.IsTerminal(int(os.Stderr.Fd()))
+```
+
+## Existing Test Patterns
+
+- **MockFetcher:** `internal/fetch/mock.go` — maps for Refs, Tags, Trees, Files
+- **Temp dirs:** Tests use `t.TempDir()` for isolation
+- **Cobra testing:** `rootCmd.SetArgs([]string{...})` + capture output
+- **No table-driven tests:** individual test functions throughout
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `internal/cli/add.go` | `craft add` command |
+| `internal/cli/add_test.go` | Tests for add command |
+| `internal/cli/remove.go` | `craft remove` command |
+| `internal/cli/remove_test.go` | Tests for remove command |
+| `internal/ui/progress.go` | TTY-aware progress/spinner |
+| `internal/ui/tree.go` | Dependency tree renderer |
+| `internal/ui/progress_test.go` | Progress tests |
+| `internal/ui/tree_test.go` | Tree renderer tests |
+| `README.md` | Project documentation (replace existing minimal) |
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `internal/cli/root.go` | Register addCmd, removeCmd |
+| `internal/cli/install.go` | Add progress output + tree display |
+| `internal/cli/update.go` | Add progress output + tree display |
+| `internal/agent/detect.go` | Return all detected agents (multi-agent support) |
+| `internal/agent/detect_test.go` | Test multi-agent scenarios |
+| `go.mod` | Add golang.org/x/term as direct dep |

--- a/.paw/work/craft-polish/artifacts/CodeResearch.md
+++ b/.paw/work/craft-polish/artifacts/CodeResearch.md
@@ -75,7 +75,7 @@ isTerminal := term.IsTerminal(int(os.Stderr.Fd()))
 | `internal/ui/tree.go` | Dependency tree renderer |
 | `internal/ui/progress_test.go` | Progress tests |
 | `internal/ui/tree_test.go` | Tree renderer tests |
-| `README.md` | Project documentation (replace existing minimal) |
+| `README.md` | Project documentation (expand existing 166-line README, not replace) |
 
 ## Files to Modify
 

--- a/.paw/work/craft-polish/artifacts/ImplementationPlan.md
+++ b/.paw/work/craft-polish/artifacts/ImplementationPlan.md
@@ -1,0 +1,88 @@
+# ImplementationPlan: craft-polish
+
+## Architecture Overview
+
+Workflow 3 adds two commands (`craft add`, `craft remove`), an internal UI package for progress and tree rendering, multi-agent interactive detection, improved error messages, and README documentation. All new code follows existing patterns (cobra commands, atomic writes, MockFetcher for tests).
+
+## Phase 1: UI Package — Progress & Tree Rendering
+
+**Goal:** Create `internal/ui/` with TTY-aware progress output and dependency tree rendering.
+
+**Changes:**
+- Create `internal/ui/progress.go` — `Progress` struct with `Start()`, `Update()`, `Done()`, `Fail()` methods. Writes status lines to stderr using `\r` carriage return on TTY, simple line-per-phase when not TTY. No external deps.
+- Create `internal/ui/tree.go` — `RenderTree()` function that takes resolved dependencies and renders a box-drawing tree (├──, └──, │) to a writer.
+- Create `internal/ui/progress_test.go` — test progress output in non-TTY mode (buffer).
+- Create `internal/ui/tree_test.go` — test tree rendering against expected output.
+- Add `golang.org/x/term` as direct dependency in `go.mod` for TTY detection.
+
+**Success Criteria:**
+- `go test ./internal/ui/...` passes
+- Progress struct produces correct output for both TTY and non-TTY modes
+- Tree renderer produces correctly formatted dependency trees
+
+## Phase 2: `craft add` Command
+
+**Goal:** Implement `craft add [alias] <url>` with dependency verification and optional install.
+
+**Changes:**
+- Create `internal/cli/add.go` — `addCmd` cobra command. Parses URL, derives alias from package identity if not provided, validates against existing deps, resolves to verify skills exist, updates manifest atomically.
+- Register `addCmd` in `internal/cli/root.go`.
+- Create `internal/cli/add_test.go` — tests: add new dep, add with alias, add duplicate (update version), add invalid URL, add with --install flag.
+- Add `--install` flag to trigger full install pipeline after add.
+
+**Success Criteria:**
+- `craft add github.com/org/repo@v1.0.0` adds dependency to craft.yaml
+- `craft add my-alias github.com/org/repo@v1.0.0` adds with custom alias
+- Existing dependency is updated with confirmation message
+- Invalid/unreachable deps produce clear error messages
+- `go test ./internal/cli/...` passes
+
+## Phase 3: `craft remove` Command
+
+**Goal:** Implement `craft remove <alias>` with orphan cleanup.
+
+**Changes:**
+- Create `internal/cli/remove.go` — `removeCmd` cobra command. Validates alias exists, removes from manifest, removes from pinfile, identifies orphaned skills, removes orphaned skill directories from install target.
+- Register `removeCmd` in `internal/cli/root.go`.
+- Create `internal/cli/remove_test.go` — tests: remove existing dep, remove non-existent alias (error), remove with orphan cleanup, remove last dependency.
+- Add `--target` flag for install path override (for cleanup).
+
+**Success Criteria:**
+- `craft remove <alias>` removes from craft.yaml and craft.pin.yaml
+- Orphaned skills are cleaned from install target
+- Non-existent alias produces error listing available aliases
+- `go test ./internal/cli/...` passes
+
+## Phase 4: Multi-Agent Detection & Progress Integration
+
+**Goal:** Enhance agent detection for interactive multi-agent prompts. Wire progress UI into install/update commands.
+
+**Changes:**
+- Modify `internal/agent/detect.go` — add `DetectAll()` returning all detected agents instead of erroring. Keep `Detect()` for backward compat.
+- Update `internal/agent/detect_test.go` — add multi-agent tests.
+- Modify `internal/cli/install.go` — integrate progress UI (phases: resolving, fetching, installing), add tree display on completion. When multi-agent detected and TTY, prompt for choice.
+- Modify `internal/cli/update.go` — integrate progress UI and tree display.
+- Improve error messages across install.go and update.go with hint patterns.
+
+**Success Criteria:**
+- Multi-agent detection prompts interactively on TTY, errors with hint on non-TTY
+- Install/update show progress phases and dependency tree on completion
+- All existing tests pass
+- `go build ./...` passes
+
+## Phase 5: Error Messages & README
+
+**Goal:** Polish error messages across all commands and write comprehensive README.
+
+**Changes:**
+- Audit and improve error messages in: install.go, update.go, add.go, remove.go, validate.go — ensure all follow `error: <msg>\n  hint: <action>` pattern.
+- Create/update `README.md` — sections: Overview, Installation, Quick Start, Commands (init, validate, install, update, add, remove, cache clean, version), craft.yaml Reference, craft.pin.yaml Reference, Agent Support, Known Limitations.
+- Run full test suite: `go test ./...`
+- Run `go vet ./...`
+- Build: `go build ./cmd/craft`
+
+**Success Criteria:**
+- All error messages include actionable hints
+- README covers all 8 commands with examples
+- Full test suite passes
+- Build succeeds cleanly

--- a/.paw/work/craft-polish/artifacts/ImplementationPlan.md
+++ b/.paw/work/craft-polish/artifacts/ImplementationPlan.md
@@ -9,32 +9,35 @@ Workflow 3 adds two commands (`craft add`, `craft remove`), an internal UI packa
 **Goal:** Create `internal/ui/` with TTY-aware progress output and dependency tree rendering.
 
 **Changes:**
-- Create `internal/ui/progress.go` — `Progress` struct with `Start()`, `Update()`, `Done()`, `Fail()` methods. Writes status lines to stderr using `\r` carriage return on TTY, simple line-per-phase when not TTY. No external deps.
-- Create `internal/ui/tree.go` — `RenderTree()` function that takes resolved dependencies and renders a box-drawing tree (├──, └──, │) to a writer.
-- Create `internal/ui/progress_test.go` — test progress output in non-TTY mode (buffer).
-- Create `internal/ui/tree_test.go` — test tree rendering against expected output.
-- Add `golang.org/x/term` as direct dependency in `go.mod` for TTY detection.
+- Create `internal/ui/progress.go` — `Progress` struct with `Start()`, `Update()`, `Done()`, `Fail()` methods. Writes status lines to stderr using `\r` carriage return on TTY. Suppresses all progress output when stderr is not a TTY (CI-friendly, per NFR-2). No external deps for rendering.
+- Create `internal/ui/tree.go` — `RenderTree()` function that takes resolved dependencies AND local skill paths, renders a box-drawing tree (├──, └──, │) to a writer. Local skills shown separately at the top of the tree output.
+- Create `internal/ui/progress_test.go` — test progress output: verify TTY mode produces status lines, non-TTY mode produces no output.
+- Create `internal/ui/tree_test.go` — test tree rendering against expected output including local skills section and empty local skills case.
+- Add `golang.org/x/term` as direct dependency in `go.mod` for TTY detection (already transitive via go-git).
 
 **Success Criteria:**
 - `go test ./internal/ui/...` passes
-- Progress struct produces correct output for both TTY and non-TTY modes
-- Tree renderer produces correctly formatted dependency trees
+- Progress struct produces status lines on TTY, no output on non-TTY
+- Tree renderer produces correctly formatted dependency trees with local skills section at top
+- Count progress format supports "Fetching dependency 2/5..." pattern
 
 ## Phase 2: `craft add` Command
 
 **Goal:** Implement `craft add [alias] <url>` with dependency verification and optional install.
 
 **Changes:**
-- Create `internal/cli/add.go` — `addCmd` cobra command. Parses URL, derives alias from package identity if not provided, validates against existing deps, resolves to verify skills exist, updates manifest atomically.
+- Create `internal/cli/add.go` — `addCmd` cobra command. Parses URL, derives alias from package identity if not provided, validates against existing deps. Validation strategy: load current manifest → add new dep in memory → call `Resolve()` with full manifest and `ForceResolve` for the new dep → on success, write manifest atomically. Updates version if dependency already exists (with confirmation message).
 - Register `addCmd` in `internal/cli/root.go`.
-- Create `internal/cli/add_test.go` — tests: add new dep, add with alias, add duplicate (update version), add invalid URL, add with --install flag.
-- Add `--install` flag to trigger full install pipeline after add.
+- Create `internal/cli/add_test.go` — tests: add new dep, add with alias, add duplicate (update version), add invalid URL, add with --install flag, add without craft.yaml (error with "Run `craft init`" hint).
+- Add `--install` flag to trigger full install pipeline after add. Note: in Phase 2, this runs the basic install pipeline; progress UI is retroactively added in Phase 4.
 
 **Success Criteria:**
 - `craft add github.com/org/repo@v1.0.0` adds dependency to craft.yaml
 - `craft add my-alias github.com/org/repo@v1.0.0` adds with custom alias
 - Existing dependency is updated with confirmation message
-- Invalid/unreachable deps produce clear error messages
+- Prints summary: skill names discovered, version resolved
+- Invalid/unreachable deps produce clear error messages with hints
+- Missing craft.yaml produces "Run `craft init` to create one" hint
 - `go test ./internal/cli/...` passes
 
 ## Phase 3: `craft remove` Command
@@ -42,14 +45,14 @@ Workflow 3 adds two commands (`craft add`, `craft remove`), an internal UI packa
 **Goal:** Implement `craft remove <alias>` with orphan cleanup.
 
 **Changes:**
-- Create `internal/cli/remove.go` — `removeCmd` cobra command. Validates alias exists, removes from manifest, removes from pinfile, identifies orphaned skills, removes orphaned skill directories from install target.
+- Create `internal/cli/remove.go` — `removeCmd` cobra command. Validates alias exists, removes from manifest, removes from pinfile. Orphan detection algorithm: collect all skill names from remaining deps' pinfile entries, diff against removed dep's skills, delete only skills not in the remaining set. Removes orphaned skill directories from install target.
 - Register `removeCmd` in `internal/cli/root.go`.
-- Create `internal/cli/remove_test.go` — tests: remove existing dep, remove non-existent alias (error), remove with orphan cleanup, remove last dependency.
-- Add `--target` flag for install path override (for cleanup).
+- Create `internal/cli/remove_test.go` — tests: remove existing dep, remove non-existent alias (error listing available aliases), remove with orphan cleanup, remove with shared skills (verify shared skills retained), remove last dependency.
+- Add `--target` flag for install path override (for cleanup), matching install/update behavior.
 
 **Success Criteria:**
 - `craft remove <alias>` removes from craft.yaml and craft.pin.yaml
-- Orphaned skills are cleaned from install target
+- Orphaned skills are cleaned from install target; shared skills are retained
 - Non-existent alias produces error listing available aliases
 - `go test ./internal/cli/...` passes
 
@@ -60,13 +63,15 @@ Workflow 3 adds two commands (`craft add`, `craft remove`), an internal UI packa
 **Changes:**
 - Modify `internal/agent/detect.go` — add `DetectAll()` returning all detected agents instead of erroring. Keep `Detect()` for backward compat.
 - Update `internal/agent/detect_test.go` — add multi-agent tests.
-- Modify `internal/cli/install.go` — integrate progress UI (phases: resolving, fetching, installing), add tree display on completion. When multi-agent detected and TTY, prompt for choice.
-- Modify `internal/cli/update.go` — integrate progress UI and tree display.
-- Improve error messages across install.go and update.go with hint patterns.
+- Modify `internal/cli/install.go` — integrate progress UI (phases: resolving, fetching, installing), add tree display on completion to stderr (via `cmd.ErrOrStderr()`). When multi-agent detected and stdin is TTY, prompt for choice (Claude Code / Copilot / Both). No persistence for MVP — prompt each time. Refactor core install logic into reusable function for `craft add --install`.
+- Modify `internal/cli/update.go` — integrate progress UI and tree display (stderr).
+- Improve error messages across install.go and update.go with `hint:` patterns.
+- Migrate existing `fix:` keyword in validate.go to `hint:` for consistency.
 
 **Success Criteria:**
-- Multi-agent detection prompts interactively on TTY, errors with hint on non-TTY
-- Install/update show progress phases and dependency tree on completion
+- Multi-agent detection prompts interactively on stdin TTY, errors with `--target` hint on non-TTY
+- "Both" option installs to both agent paths
+- Install/update show progress phases on stderr TTY and dependency tree on completion to stderr
 - All existing tests pass
 - `go build ./...` passes
 
@@ -75,8 +80,15 @@ Workflow 3 adds two commands (`craft add`, `craft remove`), an internal UI packa
 **Goal:** Polish error messages across all commands and write comprehensive README.
 
 **Changes:**
-- Audit and improve error messages in: install.go, update.go, add.go, remove.go, validate.go — ensure all follow `error: <msg>\n  hint: <action>` pattern.
-- Create/update `README.md` — sections: Overview, Installation, Quick Start, Commands (init, validate, install, update, add, remove, cache clean, version), craft.yaml Reference, craft.pin.yaml Reference, Agent Support, Known Limitations.
+- Audit and improve error messages in all commands. Specific patterns from Spec US-6:
+  1. Missing `craft.yaml` → "Run `craft init` to create one" (add.go, install.go, update.go, remove.go)
+  2. Repository not found → "Check the URL or set GITHUB_TOKEN for private repos" (install.go, add.go)
+  3. No skills found → "Ensure the repo has SKILL.md files" (install.go, add.go)
+  4. Alias not found → list available aliases (remove.go, update.go)
+  5. Version tag doesn't exist → list available tags up to 10 (add.go, update.go — ListTags() exists in fetcher)
+  6. Network errors → "Check your connection or run with cached data" (install.go, update.go, add.go)
+- Ensure all use `hint:` keyword (not `fix:`), including migrating validate.go
+- Update README.md — expand existing 166-line README (not replace). Add sections: Installation, Quick Start walkthrough, document 3 new commands (add, remove, cache clean), Agent Support details, Known Limitations (go-git SSH, monorepo paths). Preserve existing content structure.
 - Run full test suite: `go test ./...`
 - Run `go vet ./...`
 - Build: `go build ./cmd/craft`

--- a/.paw/work/craft-polish/artifacts/Spec.md
+++ b/.paw/work/craft-polish/artifacts/Spec.md
@@ -1,0 +1,156 @@
+# Spec: Craft Polish — Package Operations & UI
+
+## Overview
+
+Workflow 3 of 3 for craft (Agent Skills Package Manager). Adds the remaining two CLI commands (`craft add`, `craft remove`), introduces npm-style UI with progress indicators and dependency tree visualization, improves multi-agent detection UX, enhances error messages, and delivers project documentation (README).
+
+## User Stories
+
+### US-1: Adding a Dependency
+**As a** skill author,
+**I want to** run `craft add github.com/org/repo@v1.0.0`
+**So that** the dependency is added to my `craft.yaml`, verified, and optionally installed — without manually editing YAML.
+
+**Acceptance Criteria:**
+- Accepts git URL format: `github.com/org/repo@v1.0.0`
+- Accepts optional alias: `craft add my-alias github.com/org/repo@v1.0.0`
+- Resolves the dependency to verify it exists, has valid skills, and does not collide
+- Adds the dependency entry to `craft.yaml` (preserving existing content)
+- If `--install` flag is passed, runs the full install pipeline after adding
+- If the dependency already exists in `craft.yaml`, updates the version (with confirmation message)
+- Prints summary: skill names discovered, version resolved
+- On failure: clear error with suggestion (repo not found → auth hint; no skills → check SKILL.md)
+
+### US-2: Removing a Dependency
+**As a** skill author,
+**I want to** run `craft remove <alias>`
+**So that** the dependency and its orphaned skills are cleaned up from my project.
+
+**Acceptance Criteria:**
+- Accepts the dependency alias (the key in `craft.yaml` dependencies map)
+- Removes the dependency from `craft.yaml`
+- Removes the dependency's entry from `craft.pin.yaml` (if pinfile exists)
+- Identifies orphaned skills (skills only provided by the removed dependency, not by any remaining dependency)
+- Removes orphaned skill directories from the install target
+- Prints summary: what was removed, which skills were cleaned up
+- If alias doesn't exist in `craft.yaml`, error with available aliases listed
+- Handles transitive deps: only removes skills that are truly orphaned (not needed by other remaining deps)
+
+### US-3: Progress Indicators
+**As a** skill consumer,
+**I want to** see progress during `craft install` and `craft update`
+**So that** I know the tool is working and approximately how long it will take.
+
+**Acceptance Criteria:**
+- Shows spinner/status line during: git fetch, dependency resolution, skill installation
+- Displays phase transitions: "Resolving dependencies...", "Fetching github.com/org/repo...", "Installing skills..."
+- Shows count progress: "Fetching dependency 2/5..."
+- On completion: summary line with counts (e.g., "Installed 8 skills from 3 packages")
+- On error: progress stops, error is displayed clearly
+- Output goes to stderr (so stdout remains clean for scripting)
+- No progress output when stderr is not a TTY (CI-friendly)
+
+### US-4: Dependency Tree Visualization
+**As a** skill consumer,
+**I want to** see a tree view of my resolved dependencies after install
+**So that** I understand what was installed and where skills came from.
+
+**Acceptance Criteria:**
+- After successful install/update, prints a tree like:
+  ```
+  code-quality@1.0.0
+  ├── git-operations (github.com/example/git-skills@v1.0.0)
+  │   ├── git-commit
+  │   ├── git-branch
+  │   └── git-operations
+  └── style-guides (github.com/other-org/style-skills@v2.3.1)
+      ├── python-style
+      └── js-style
+  ```
+- Tree shows: package name, dependency alias, URL+version, and skill names under each
+- Local skills (from `skills[]`) shown separately at the top
+- Output goes to stderr
+
+### US-5: Multi-Agent Detection
+**As a** user with both Claude Code and GitHub Copilot installed,
+**I want to** be prompted to choose an install target
+**So that** I'm not blocked by an error when both agents are detected.
+
+**Acceptance Criteria:**
+- When multiple agents detected, prompt interactively: Claude Code / Copilot / Both
+- When stdin is not a TTY, fall back to error with `--target` suggestion (non-interactive)
+- `--target` flag always overrides detection (no prompt)
+- Persist nothing for MVP — ask each time (config persistence is post-MVP)
+
+### US-6: Improved Error Messages
+**As a** craft user,
+**I want to** see actionable error messages with suggestions
+**So that** I can fix issues without reading documentation.
+
+**Acceptance Criteria:**
+- All errors follow pattern: `error: <what happened>\n  hint: <what to do>`
+- Missing `craft.yaml` → "Run `craft init` to create one"
+- Repository not found → "Check the URL or set GITHUB_TOKEN for private repos"
+- No skills found in dependency → "Ensure the repo has SKILL.md files"
+- Dependency alias not found → list available aliases
+- Version tag doesn't exist → list available tags (up to 10)
+- Network errors → "Check your connection or run with cached data"
+
+### US-7: README Documentation
+**As a** potential craft user,
+**I want to** read a comprehensive README
+**So that** I can understand what craft does, how to install it, and how to use it.
+
+**Acceptance Criteria:**
+- Sections: Overview, Installation, Quick Start, Commands Reference, Configuration, craft.yaml Reference, craft.pin.yaml Reference, Agent Support, Known Limitations
+- Installation: `go install` command, binary download mention
+- Quick Start: end-to-end example from `craft init` to `craft install`
+- Each command documented with usage, flags, and examples
+- Known limitations documented (go-git SSH, monorepo paths, etc.)
+
+## Requirements
+
+### Functional Requirements
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| FR-1 | `craft add <url>` adds dependency to craft.yaml | Must |
+| FR-2 | `craft add <alias> <url>` adds with custom alias | Must |
+| FR-3 | `craft add --install` triggers install after add | Must |
+| FR-4 | `craft add` validates dependency resolves before committing to manifest | Must |
+| FR-5 | `craft remove <alias>` removes dependency from craft.yaml | Must |
+| FR-6 | `craft remove` cleans up orphaned skills from install target | Must |
+| FR-7 | `craft remove` updates craft.pin.yaml | Must |
+| FR-8 | Progress indicators during install/update operations | Must |
+| FR-9 | Dependency tree visualization after install/update | Must |
+| FR-10 | Interactive multi-agent prompt when multiple agents detected | Should |
+| FR-11 | Improved error messages with hints across all commands | Must |
+| FR-12 | README with complete usage documentation | Must |
+
+### Non-Functional Requirements
+
+| ID | Requirement |
+|----|-------------|
+| NFR-1 | Progress output goes to stderr; data output to stdout |
+| NFR-2 | No progress/color when stderr is not a TTY (CI-friendly) |
+| NFR-3 | No new external dependencies for progress UI (use stdlib) |
+| NFR-4 | All new code has unit tests |
+| NFR-5 | Existing tests continue to pass |
+
+## Technical Constraints
+
+- **No new dependencies**: Progress UI implemented with stdlib (ANSI escape codes + `\r` carriage return). No external terminal UI libraries.
+- **TTY detection**: Use `os.Stderr.Fd()` with `golang.org/x/term.IsTerminal()` — already a transitive dependency via go-git's SSH code. If not available, use simple `os.Stat()` check.
+- **Atomic manifest writes**: `craft add` and `craft remove` must write craft.yaml atomically (temp file + rename), matching existing patterns.
+- **Existing interfaces**: `craft add` reuses the resolver's `Resolve()` for validation. No new fetcher interface methods needed.
+
+## Success Criteria
+
+1. `craft add github.com/org/repo@v1.0.0` adds the dependency, reports discovered skills
+2. `craft remove <alias>` removes the dependency, cleans orphaned skills, updates pinfile
+3. `craft install` shows progress phases and a dependency tree on completion
+4. Multi-agent detection prompts instead of erroring
+5. All error messages include actionable hints
+6. README covers all 8 commands with examples
+7. All existing tests pass; new commands have full test coverage
+8. `go vet` and `go build` pass cleanly

--- a/.paw/work/craft-polish/artifacts/Spec.md
+++ b/.paw/work/craft-polish/artifacts/Spec.md
@@ -31,7 +31,7 @@ Workflow 3 of 3 for craft (Agent Skills Package Manager). Adds the remaining two
 - Removes the dependency from `craft.yaml`
 - Removes the dependency's entry from `craft.pin.yaml` (if pinfile exists)
 - Identifies orphaned skills (skills only provided by the removed dependency, not by any remaining dependency)
-- Removes orphaned skill directories from the install target
+- Removes orphaned skill directories from the install target (uses `--target` flag or agent auto-detection, matching install/update behavior)
 - Prints summary: what was removed, which skills were cleaned up
 - If alias doesn't exist in `craft.yaml`, error with available aliases listed
 - Handles transitive deps: only removes skills that are truly orphaned (not needed by other remaining deps)
@@ -88,7 +88,7 @@ Workflow 3 of 3 for craft (Agent Skills Package Manager). Adds the remaining two
 **So that** I can fix issues without reading documentation.
 
 **Acceptance Criteria:**
-- All errors follow pattern: `error: <what happened>\n  hint: <what to do>`
+- All errors follow pattern: `error: <what happened>\n  hint: <what to do>` (migrates existing `fix:` keyword in validate.go to `hint:` for consistency)
 - Missing `craft.yaml` → "Run `craft init` to create one"
 - Repository not found → "Check the URL or set GITHUB_TOKEN for private repos"
 - No skills found in dependency → "Ensure the repo has SKILL.md files"
@@ -133,7 +133,7 @@ Workflow 3 of 3 for craft (Agent Skills Package Manager). Adds the remaining two
 |----|-------------|
 | NFR-1 | Progress output goes to stderr; data output to stdout |
 | NFR-2 | No progress/color when stderr is not a TTY (CI-friendly) |
-| NFR-3 | No new external dependencies for progress UI (use stdlib) |
+| NFR-3 | No new external dependencies for progress UI rendering (use stdlib ANSI codes). `golang.org/x/term` promoted from transitive to direct for TTY detection. |
 | NFR-4 | All new code has unit tests |
 | NFR-5 | Existing tests continue to pass |
 

--- a/README.md
+++ b/README.md
@@ -132,8 +132,50 @@ go build -o craft ./cmd/craft
 | `craft init` | Interactive package setup with skill auto-discovery |
 | `craft install` | Resolve, pin, and install all dependencies |
 | `craft update [alias]` | Update dependencies to latest semver tags |
+| `craft add [alias] <url>` | Add a dependency (verify, then update manifest) |
+| `craft remove <alias>` | Remove a dependency and clean up orphaned skills |
 | `craft validate` | Run all validation checks (schema, paths, frontmatter, deps, collisions) |
+| `craft cache clean` | Remove all cached repositories from `~/.craft/cache/` |
 | `craft version` | Print version and exit |
+
+### `craft add`
+
+Add a dependency to your `craft.yaml`. The dependency is resolved and verified before the manifest is updated.
+
+```bash
+# Add with auto-derived alias (uses repo name)
+$ craft add github.com/acme/utility-skills@v1.0.0
+Added "utility-skills" → github.com/acme/utility-skills@v1.0.0
+  skills: git-helper, file-parser
+  version: v1.0.0
+
+# Add with custom alias
+$ craft add utils github.com/acme/utility-skills@v1.0.0
+
+# Add and immediately install
+$ craft add --install github.com/acme/utility-skills@v1.0.0
+```
+
+### `craft remove`
+
+Remove a dependency and clean up skills that are no longer needed by any remaining dependency.
+
+```bash
+$ craft remove utils
+Removed "utils" (github.com/acme/utility-skills@v1.0.0)
+  cleaned up 2 orphaned skill(s): git-helper, file-parser
+```
+
+Skills shared with other dependencies are retained — only truly orphaned skills are removed.
+
+### `craft cache clean`
+
+Remove all cached git repositories from `~/.craft/cache/`.
+
+```bash
+$ craft cache clean
+Removed cache directory: /home/user/.craft/cache
+```
 
 ## Manifest Reference (`craft.yaml`)
 
@@ -156,6 +198,29 @@ dependencies:               # alias → host/org/repo@vX.Y.Z
 Each skill directory must contain a `SKILL.md` file — a markdown file with YAML frontmatter that declares the skill's identity. craft parses the frontmatter to extract the `name` and `description` fields, and preserves any additional fields for forward compatibility.
 
 For the full specification and a real-world example, see [Anthropic's skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator) — the canonical reference for the Agent Skills format that craft builds on.
+
+## Agent Support
+
+craft auto-detects your AI agent and installs skills to the correct directory:
+
+| Agent | Marker | Install Path |
+|-------|--------|-------------|
+| Claude Code | `~/.claude/` | `~/.claude/skills/` |
+| GitHub Copilot | `~/.copilot/` | `~/.copilot/skills/` |
+
+When both agents are detected, craft prompts you to choose. Use `--target <path>` to override auto-detection:
+
+```bash
+$ craft install --target ./my-skills
+```
+
+## Known Limitations
+
+- **go-git SSH limitations** — craft uses [go-git](https://github.com/go-git/go-git) for git operations. This means no `~/.ssh/config` ProxyJump support, no hardware token (YubiKey) auth, and no agent forwarding. Set `GITHUB_TOKEN` or `CRAFT_TOKEN` for private repos as a reliable alternative.
+- **No monorepo subpath support** — dependency URLs point to whole repositories (`github.com/org/repo@v1.0.0`). Subpath support (e.g., `repo/path/to/skills@v1`) is designed for but not yet implemented.
+- **No pre-release versions** — version tags must be strict semver (`vMAJOR.MINOR.PATCH`). Pre-release suffixes like `-beta.1` are rejected.
+- **No version ranges** — dependencies use exact versions. `craft update` bumps to the latest available tag; there are no `^` or `~` range constraints.
+- **Cache grows unbounded** — use `craft cache clean` periodically to reclaim disk space.
 
 ## Acknowledgments
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.5
 require (
 	github.com/go-git/go-git/v5 v5.17.0
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/term v0.40.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -28,6 +29,6 @@ require (
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
-	golang.org/x/sys v0.38.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -90,11 +90,11 @@ golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
-golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.37.0 h1:8EGAD0qCmHYZg6J17DvsMy9/wJ7/D/4pV/wfnld5lTU=
-golang.org/x/term v0.37.0/go.mod h1:5pB4lxRNYYVZuTLmy8oR2BH8dflOR+IbTYFD8fi3254=
+golang.org/x/term v0.40.0 h1:36e4zGLqU4yhjlmxEaagx2KuYbJq3EwY8K943ZsHcvg=
+golang.org/x/term v0.40.0/go.mod h1:w2P8uVp06p2iyKKuvXIm7N/y0UCRt3UfJTfZ7oOpglM=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.31.0 h1:aC8ghyu4JhP8VojJ2lEHBnochRno1sgL6nEi9WGFGMM=
 golang.org/x/text v0.31.0/go.mod h1:tKRAlv61yKIjGGHX/4tP1LTbc13YSec1pxVEWXzfoeM=

--- a/internal/agent/detect.go
+++ b/internal/agent/detect.go
@@ -46,28 +46,7 @@ type DetectResult struct {
 // markers under the given home directory. Returns an error if no known
 // agent is detected or if multiple agents are found, suggesting --target.
 func Detect(homeDir string) (*DetectResult, error) {
-	checks := []struct {
-		agent   Type
-		marker  string
-		install string
-	}{
-		{ClaudeCode, ".claude", filepath.Join(homeDir, ".claude", "skills")},
-		{Copilot, ".copilot", filepath.Join(homeDir, ".copilot", "skills")},
-	}
-
-	var detected []struct {
-		agent   Type
-		install string
-	}
-	for _, c := range checks {
-		markerPath := filepath.Join(homeDir, c.marker)
-		if info, err := os.Stat(markerPath); err == nil && info.IsDir() {
-			detected = append(detected, struct {
-				agent   Type
-				install string
-			}{c.agent, c.install})
-		}
-	}
+	detected := detectAgents(homeDir)
 
 	switch len(detected) {
 	case 0:
@@ -85,4 +64,40 @@ func Detect(homeDir string) (*DetectResult, error) {
 		return nil, fmt.Errorf("multiple AI agents detected (%s) — use --target <path> to specify the installation directory",
 			strings.Join(names, ", "))
 	}
+}
+
+// DetectAll returns all detected AI agents. Returns an empty slice if none
+// are found. Unlike Detect, this does not error on zero or multiple agents.
+func DetectAll(homeDir string) []DetectResult {
+	found := detectAgents(homeDir)
+	results := make([]DetectResult, len(found))
+	for i, d := range found {
+		results[i] = DetectResult{Agent: d.agent, InstallPath: d.install}
+	}
+	return results
+}
+
+type detectedEntry struct {
+	agent   Type
+	install string
+}
+
+func detectAgents(homeDir string) []detectedEntry {
+	checks := []struct {
+		agent   Type
+		marker  string
+		install string
+	}{
+		{ClaudeCode, ".claude", filepath.Join(homeDir, ".claude", "skills")},
+		{Copilot, ".copilot", filepath.Join(homeDir, ".copilot", "skills")},
+	}
+
+	var detected []detectedEntry
+	for _, c := range checks {
+		markerPath := filepath.Join(homeDir, c.marker)
+		if info, err := os.Stat(markerPath); err == nil && info.IsDir() {
+			detected = append(detected, detectedEntry{c.agent, c.install})
+		}
+	}
+	return detected
 }

--- a/internal/agent/detect_test.go
+++ b/internal/agent/detect_test.go
@@ -65,6 +65,46 @@ func TestDetectNoAgent(t *testing.T) {
 	}
 }
 
+func TestDetectAll_Multiple(t *testing.T) {
+	home := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(home, ".claude"), 0o755)
+	_ = os.MkdirAll(filepath.Join(home, ".copilot"), 0o755)
+
+	results := DetectAll(home)
+	if len(results) != 2 {
+		t.Fatalf("expected 2 agents, got %d", len(results))
+	}
+
+	agents := map[Type]bool{}
+	for _, r := range results {
+		agents[r.Agent] = true
+	}
+	if !agents[ClaudeCode] || !agents[Copilot] {
+		t.Error("expected both ClaudeCode and Copilot")
+	}
+}
+
+func TestDetectAll_None(t *testing.T) {
+	home := t.TempDir()
+	results := DetectAll(home)
+	if len(results) != 0 {
+		t.Errorf("expected 0 agents, got %d", len(results))
+	}
+}
+
+func TestDetectAll_Single(t *testing.T) {
+	home := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(home, ".claude"), 0o755)
+
+	results := DetectAll(home)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(results))
+	}
+	if results[0].Agent != ClaudeCode {
+		t.Errorf("expected ClaudeCode, got %v", results[0].Agent)
+	}
+}
+
 func TestDetectFileNotDir(t *testing.T) {
 	home := t.TempDir()
 	// Create .claude as a file, not a directory

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/erdemtuna/craft/internal/fetch"
 	installlib "github.com/erdemtuna/craft/internal/install"
 	"github.com/erdemtuna/craft/internal/manifest"
+	"github.com/erdemtuna/craft/internal/pinfile"
 	"github.com/erdemtuna/craft/internal/resolve"
 	"github.com/spf13/cobra"
 )
@@ -85,19 +85,22 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	m.Dependencies[alias] = depURL
 
 	// Validate by resolving with full manifest
-	cacheRoot, err := fetch.DefaultCacheRoot()
+	fetcher, err := newFetcher()
 	if err != nil {
 		return err
 	}
-	cache, err := fetch.NewCache(cacheRoot)
-	if err != nil {
-		return err
+
+	// Load existing pinfile to preserve pins for unchanged deps
+	var existingPinfile *pinfile.Pinfile
+	pfPath := filepath.Join(root, "craft.pin.yaml")
+	if pf, err := pinfile.ParseFile(pfPath); err == nil {
+		existingPinfile = pf
 	}
-	fetcher := fetch.NewGoGitFetcher(cache)
 
 	resolver := resolve.NewResolver(fetcher)
 	result, err := resolver.Resolve(m, resolve.ResolveOptions{
-		ForceResolve: map[string]bool{depURL: true},
+		ExistingPinfile: existingPinfile,
+		ForceResolve:    map[string]bool{depURL: true},
 	})
 	if err != nil {
 		return fmt.Errorf("dependency verification failed: %w", err)

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -10,7 +10,6 @@ import (
 	"github.com/erdemtuna/craft/internal/fetch"
 	installlib "github.com/erdemtuna/craft/internal/install"
 	"github.com/erdemtuna/craft/internal/manifest"
-	"github.com/erdemtuna/craft/internal/pinfile"
 	"github.com/erdemtuna/craft/internal/resolve"
 	"github.com/spf13/cobra"
 )
@@ -137,7 +136,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		targetPath, err := resolveInstallTarget(installTarget)
+		targetPaths, err := resolveInstallTargets(installTarget)
 		if err != nil {
 			return err
 		}
@@ -147,34 +146,14 @@ func runAdd(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		if err := installlib.Install(targetPath, skillFiles); err != nil {
-			return fmt.Errorf("installation failed: %w", err)
+		for _, targetPath := range targetPaths {
+			if err := installlib.Install(targetPath, skillFiles); err != nil {
+				return fmt.Errorf("installation failed: %w", err)
+			}
 		}
 
-		cmd.Printf("Installed %d skill(s) to %s\n", countSkills(result), targetPath)
+		cmd.Printf("Installed %d skill(s) to %s\n", countSkills(result), strings.Join(targetPaths, ", "))
 	}
 
-	return nil
-}
-
-// hintWrap wraps an error with a hint if the error message matches known patterns.
-func hintWrap(err error, url string) error {
-	msg := err.Error()
-	switch {
-	case strings.Contains(msg, "repository not found") || strings.Contains(msg, "authentication"):
-		return fmt.Errorf("%w\n  hint: check the URL or set GITHUB_TOKEN for private repos", err)
-	case strings.Contains(msg, "no skills found") || strings.Contains(msg, "no SKILL.md"):
-		return fmt.Errorf("%w\n  hint: ensure the repo contains SKILL.md files", err)
-	default:
-		return err
-	}
-}
-
-// loadExistingPinfile loads craft.pin.yaml if it exists.
-func loadExistingPinfile(root string) *pinfile.Pinfile {
-	pfPath := filepath.Join(root, "craft.pin.yaml")
-	if pf, err := pinfile.ParseFile(pfPath); err == nil {
-		return pf
-	}
 	return nil
 }

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -1,0 +1,180 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/erdemtuna/craft/internal/fetch"
+	installlib "github.com/erdemtuna/craft/internal/install"
+	"github.com/erdemtuna/craft/internal/manifest"
+	"github.com/erdemtuna/craft/internal/pinfile"
+	"github.com/erdemtuna/craft/internal/resolve"
+	"github.com/spf13/cobra"
+)
+
+var addInstall bool
+
+var addCmd = &cobra.Command{
+	Use:   "add [alias] <url>",
+	Short: "Add a dependency",
+	Long: `Add a dependency to craft.yaml. The URL must be in the format host/org/repo@vMAJOR.MINOR.PATCH.
+
+If no alias is provided, one is derived from the repository name.
+The dependency is verified by resolving it before updating the manifest.`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: runAdd,
+}
+
+func init() {
+	addCmd.Flags().BoolVar(&addInstall, "install", false, "Run install after adding the dependency")
+	addCmd.Flags().StringVar(&installTarget, "target", "", "Override agent auto-detection with a custom install path (used with --install)")
+}
+
+func runAdd(cmd *cobra.Command, args []string) error {
+	var alias, depURL string
+	if len(args) == 2 {
+		alias = args[0]
+		depURL = args[1]
+	} else {
+		depURL = args[0]
+	}
+
+	// Validate URL format
+	parsed, err := resolve.ParseDepURL(depURL)
+	if err != nil {
+		return fmt.Errorf("%w\n  hint: expected format: github.com/org/repo@v1.0.0", err)
+	}
+
+	// Derive alias from repo name if not provided
+	if alias == "" {
+		alias = parsed.Repo
+	}
+
+	root, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting working directory: %w", err)
+	}
+
+	// Parse existing manifest
+	manifestPath := filepath.Join(root, "craft.yaml")
+	m, err := manifest.ParseFile(manifestPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("craft.yaml not found\n  hint: run `craft init` to create one")
+		}
+		return fmt.Errorf("reading craft.yaml: %w", err)
+	}
+
+	// Check for existing dependency
+	isUpdate := false
+	if existing, ok := m.Dependencies[alias]; ok {
+		isUpdate = true
+		if existing == depURL {
+			cmd.Printf("Dependency %q is already at %s — nothing to do.\n", alias, depURL)
+			return nil
+		}
+		cmd.Printf("Updating %q: %s → %s\n", alias, existing, depURL)
+	}
+
+	// Add dependency in memory
+	if m.Dependencies == nil {
+		m.Dependencies = make(map[string]string)
+	}
+	m.Dependencies[alias] = depURL
+
+	// Validate by resolving with full manifest
+	cacheRoot, err := fetch.DefaultCacheRoot()
+	if err != nil {
+		return err
+	}
+	cache, err := fetch.NewCache(cacheRoot)
+	if err != nil {
+		return err
+	}
+	fetcher := fetch.NewGoGitFetcher(cache)
+
+	resolver := resolve.NewResolver(fetcher)
+	result, err := resolver.Resolve(m, resolve.ResolveOptions{
+		ForceResolve: map[string]bool{depURL: true},
+	})
+	if err != nil {
+		return fmt.Errorf("dependency verification failed: %w", err)
+	}
+
+	// Find the added dependency in results for summary
+	var addedSkills []string
+	for _, dep := range result.Resolved {
+		if dep.Alias == alias {
+			addedSkills = dep.Skills
+			break
+		}
+	}
+
+	// Write manifest atomically
+	if err := writeManifestAtomic(manifestPath, m); err != nil {
+		return err
+	}
+
+	// Print summary
+	if isUpdate {
+		cmd.Printf("Updated %q → %s\n", alias, depURL)
+	} else {
+		cmd.Printf("Added %q → %s\n", alias, depURL)
+	}
+	if len(addedSkills) > 0 {
+		cmd.Printf("  skills: %s\n", strings.Join(addedSkills, ", "))
+	}
+	cmd.Printf("  version: %s\n", parsed.GitTag())
+
+	// Optionally run install
+	if addInstall {
+		// Write pinfile
+		pfPath := filepath.Join(root, "craft.pin.yaml")
+		if err := writePinfileAtomic(pfPath, result.Pinfile); err != nil {
+			return err
+		}
+
+		targetPath, err := resolveInstallTarget(installTarget)
+		if err != nil {
+			return err
+		}
+
+		skillFiles, err := collectSkillFiles(fetcher, result)
+		if err != nil {
+			return err
+		}
+
+		if err := installlib.Install(targetPath, skillFiles); err != nil {
+			return fmt.Errorf("installation failed: %w", err)
+		}
+
+		cmd.Printf("Installed %d skill(s) to %s\n", countSkills(result), targetPath)
+	}
+
+	return nil
+}
+
+// hintWrap wraps an error with a hint if the error message matches known patterns.
+func hintWrap(err error, url string) error {
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "repository not found") || strings.Contains(msg, "authentication"):
+		return fmt.Errorf("%w\n  hint: check the URL or set GITHUB_TOKEN for private repos", err)
+	case strings.Contains(msg, "no skills found") || strings.Contains(msg, "no SKILL.md"):
+		return fmt.Errorf("%w\n  hint: ensure the repo contains SKILL.md files", err)
+	default:
+		return err
+	}
+}
+
+// loadExistingPinfile loads craft.pin.yaml if it exists.
+func loadExistingPinfile(root string) *pinfile.Pinfile {
+	pfPath := filepath.Join(root, "craft.pin.yaml")
+	if pf, err := pinfile.ParseFile(pfPath); err == nil {
+		return pf
+	}
+	return nil
+}

--- a/internal/cli/add_test.go
+++ b/internal/cli/add_test.go
@@ -1,0 +1,172 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunAdd_NewDependency(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a minimal manifest
+	manifestContent := `schema_version: 1
+name: test-pkg
+version: 0.1.0
+skills:
+  - ./skills/my-skill
+`
+	os.WriteFile(filepath.Join(dir, "craft.yaml"), []byte(manifestContent), 0644)
+	os.MkdirAll(filepath.Join(dir, "skills", "my-skill"), 0755)
+	os.WriteFile(filepath.Join(dir, "skills", "my-skill", "SKILL.md"), []byte("---\nname: my-skill\n---\n"), 0644)
+
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(dir)
+
+	// Use the rootCmd to test — but craft add requires network access
+	// so we test argument parsing and manifest-not-found scenarios
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"add", "invalid-url-no-version"})
+	err := rootCmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+	if !strings.Contains(err.Error(), "invalid dependency URL") {
+		t.Errorf("expected invalid URL error, got: %v", err)
+	}
+}
+
+func TestRunAdd_InvalidURLFormat(t *testing.T) {
+	dir := t.TempDir()
+
+	manifestContent := `schema_version: 1
+name: test-pkg
+version: 0.1.0
+skills:
+  - ./skills/s
+`
+	os.WriteFile(filepath.Join(dir, "craft.yaml"), []byte(manifestContent), 0644)
+	os.MkdirAll(filepath.Join(dir, "skills", "s"), 0755)
+	os.WriteFile(filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"), 0644)
+
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(dir)
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"add", "not-a-valid-url"})
+	err := rootCmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+	if !strings.Contains(err.Error(), "hint") {
+		t.Errorf("expected hint in error message, got: %v", err)
+	}
+}
+
+func TestRunAdd_NoManifest(t *testing.T) {
+	dir := t.TempDir()
+
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(dir)
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"add", "github.com/org/repo@v1.0.0"})
+	err := rootCmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected error when craft.yaml missing")
+	}
+	if !strings.Contains(err.Error(), "craft init") {
+		t.Errorf("expected hint about craft init, got: %v", err)
+	}
+}
+
+func TestRunAdd_TooManyArgs(t *testing.T) {
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"add", "a", "b", "c"})
+	err := rootCmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected error for too many args")
+	}
+}
+
+func TestRunAdd_AlreadyExists(t *testing.T) {
+	dir := t.TempDir()
+
+	manifestContent := `schema_version: 1
+name: test-pkg
+version: 0.1.0
+skills:
+  - ./skills/s
+dependencies:
+  my-dep: github.com/org/repo@v1.0.0
+`
+	os.WriteFile(filepath.Join(dir, "craft.yaml"), []byte(manifestContent), 0644)
+	os.MkdirAll(filepath.Join(dir, "skills", "s"), 0755)
+	os.WriteFile(filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"), 0644)
+
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(dir)
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"add", "my-dep", "github.com/org/repo@v1.0.0"})
+	err := rootCmd.Execute()
+
+	// Should succeed with "already at" message (no network needed)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "already at") {
+		t.Errorf("expected 'already at' message, got: %s", buf.String())
+	}
+}
+
+func TestRunAdd_AliasDerivation(t *testing.T) {
+	// Test that alias is derived from repo name
+	dir := t.TempDir()
+
+	manifestContent := `schema_version: 1
+name: test-pkg
+version: 0.1.0
+skills:
+  - ./skills/s
+`
+	os.WriteFile(filepath.Join(dir, "craft.yaml"), []byte(manifestContent), 0644)
+	os.MkdirAll(filepath.Join(dir, "skills", "s"), 0755)
+	os.WriteFile(filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"), 0644)
+
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(dir)
+
+	// This will fail at resolution (network) but tests URL parsing + alias derivation
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"add", "github.com/org/my-skills@v1.0.0"})
+	err := rootCmd.Execute()
+
+	// Error is expected (network), but should get past URL parsing
+	if err != nil && strings.Contains(err.Error(), "invalid dependency URL") {
+		t.Errorf("should have parsed URL correctly, got: %v", err)
+	}
+}

--- a/internal/cli/add_test.go
+++ b/internal/cli/add_test.go
@@ -8,6 +8,32 @@ import (
 	"testing"
 )
 
+func testChdir(t *testing.T, dir string) {
+	t.Helper()
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testWriteFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testMkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0755); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRunAdd_NewDependency(t *testing.T) {
 	dir := t.TempDir()
 
@@ -18,13 +44,11 @@ version: 0.1.0
 skills:
   - ./skills/my-skill
 `
-	os.WriteFile(filepath.Join(dir, "craft.yaml"), []byte(manifestContent), 0644)
-	os.MkdirAll(filepath.Join(dir, "skills", "my-skill"), 0755)
-	os.WriteFile(filepath.Join(dir, "skills", "my-skill", "SKILL.md"), []byte("---\nname: my-skill\n---\n"), 0644)
+	testWriteFile(t, filepath.Join(dir, "craft.yaml"), []byte(manifestContent))
+	testMkdirAll(t, filepath.Join(dir, "skills", "my-skill"))
+	testWriteFile(t, filepath.Join(dir, "skills", "my-skill", "SKILL.md"), []byte("---\nname: my-skill\n---\n"))
 
-	oldWd, _ := os.Getwd()
-	defer os.Chdir(oldWd)
-	os.Chdir(dir)
+	testChdir(t, dir)
 
 	// Use the rootCmd to test — but craft add requires network access
 	// so we test argument parsing and manifest-not-found scenarios
@@ -51,13 +75,11 @@ version: 0.1.0
 skills:
   - ./skills/s
 `
-	os.WriteFile(filepath.Join(dir, "craft.yaml"), []byte(manifestContent), 0644)
-	os.MkdirAll(filepath.Join(dir, "skills", "s"), 0755)
-	os.WriteFile(filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"), 0644)
+	testWriteFile(t, filepath.Join(dir, "craft.yaml"), []byte(manifestContent))
+	testMkdirAll(t, filepath.Join(dir, "skills", "s"))
+	testWriteFile(t, filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"))
 
-	oldWd, _ := os.Getwd()
-	defer os.Chdir(oldWd)
-	os.Chdir(dir)
+	testChdir(t, dir)
 
 	var buf bytes.Buffer
 	rootCmd.SetOut(&buf)
@@ -76,9 +98,7 @@ skills:
 func TestRunAdd_NoManifest(t *testing.T) {
 	dir := t.TempDir()
 
-	oldWd, _ := os.Getwd()
-	defer os.Chdir(oldWd)
-	os.Chdir(dir)
+	testChdir(t, dir)
 
 	var buf bytes.Buffer
 	rootCmd.SetOut(&buf)
@@ -117,13 +137,11 @@ skills:
 dependencies:
   my-dep: github.com/org/repo@v1.0.0
 `
-	os.WriteFile(filepath.Join(dir, "craft.yaml"), []byte(manifestContent), 0644)
-	os.MkdirAll(filepath.Join(dir, "skills", "s"), 0755)
-	os.WriteFile(filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"), 0644)
+	testWriteFile(t, filepath.Join(dir, "craft.yaml"), []byte(manifestContent))
+	testMkdirAll(t, filepath.Join(dir, "skills", "s"))
+	testWriteFile(t, filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"))
 
-	oldWd, _ := os.Getwd()
-	defer os.Chdir(oldWd)
-	os.Chdir(dir)
+	testChdir(t, dir)
 
 	var buf bytes.Buffer
 	rootCmd.SetOut(&buf)
@@ -150,13 +168,11 @@ version: 0.1.0
 skills:
   - ./skills/s
 `
-	os.WriteFile(filepath.Join(dir, "craft.yaml"), []byte(manifestContent), 0644)
-	os.MkdirAll(filepath.Join(dir, "skills", "s"), 0755)
-	os.WriteFile(filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"), 0644)
+	testWriteFile(t, filepath.Join(dir, "craft.yaml"), []byte(manifestContent))
+	testMkdirAll(t, filepath.Join(dir, "skills", "s"))
+	testWriteFile(t, filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"))
 
-	oldWd, _ := os.Getwd()
-	defer os.Chdir(oldWd)
-	os.Chdir(dir)
+	testChdir(t, dir)
 
 	// This will fail at resolution (network) but tests URL parsing + alias derivation
 	var buf bytes.Buffer

--- a/internal/cli/atomic.go
+++ b/internal/cli/atomic.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// writeAtomic writes to a file atomically by writing to a temp file first,
+// then renaming it to the target path.
+func writeAtomic(path string, writeFn func(w io.Writer) error) error {
+	tmpPath := path + ".tmp"
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	if err := writeFn(f); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("renaming temp file: %w", err)
+	}
+	return nil
+}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -130,29 +130,9 @@ func runInstall(cmd *cobra.Command, args []string) error {
 }
 
 func writePinfileAtomic(path string, pf *pinfile.Pinfile) error {
-	tmpPath := path + ".tmp"
-	f, err := os.Create(tmpPath)
-	if err != nil {
-		return fmt.Errorf("creating pinfile: %w", err)
-	}
-
-	if err := pinfile.Write(pf, f); err != nil {
-		_ = f.Close()
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("writing pinfile: %w", err)
-	}
-
-	if err := f.Close(); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("writing pinfile: %w", err)
-	}
-
-	if err := os.Rename(tmpPath, path); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("saving pinfile: %w", err)
-	}
-
-	return nil
+	return writeAtomic(path, func(w io.Writer) error {
+		return pinfile.Write(pf, w)
+	})
 }
 
 // resolveInstallTargets returns one or more install target paths.

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -86,34 +86,31 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Determine install path
-	targetPath, err := resolveInstallTarget(installTarget)
+	// Determine install path(s)
+	targetPaths, err := resolveInstallTargets(installTarget)
 	if err != nil {
 		return err
 	}
 
 	// Collect skill files for installation
-	total := len(result.Resolved)
-	for i, dep := range result.Resolved {
-		progress.UpdateCount("Fetching dependency", i+1, total)
-		_ = dep
-	}
 	skillFiles, err := collectSkillFiles(fetcher, result)
 	if err != nil {
 		progress.Fail("Fetching failed")
 		return err
 	}
 
-	// Install
+	// Install to each target path
 	progress.Update("Installing skills...")
-	if err := installlib.Install(targetPath, skillFiles); err != nil {
-		progress.Fail("Installation failed")
-		return fmt.Errorf("installation failed: %w", err)
+	for _, targetPath := range targetPaths {
+		if err := installlib.Install(targetPath, skillFiles); err != nil {
+			progress.Fail("Installation failed")
+			return fmt.Errorf("installation failed: %w", err)
+		}
 	}
 
 	skillCount := countSkills(result)
 	progress.Done(fmt.Sprintf("Installed %d skill(s) from %d package(s) to %s",
-		skillCount, len(result.Resolved), targetPath))
+		skillCount, len(result.Resolved), strings.Join(targetPaths, ", ")))
 
 	// Print dependency tree to stderr
 	printDependencyTree(cmd, m, result)
@@ -147,26 +144,29 @@ func writePinfileAtomic(path string, pf *pinfile.Pinfile) error {
 	return nil
 }
 
-func resolveInstallTarget(target string) (string, error) {
+// resolveInstallTargets returns one or more install target paths.
+// If --target is provided, returns that single path.
+// If multiple agents detected on TTY, prompts and may return multiple paths.
+func resolveInstallTargets(target string) ([]string, error) {
 	if target != "" {
-		return target, nil
+		return []string{target}, nil
 	}
 
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("determining home directory: %w", err)
+		return nil, fmt.Errorf("determining home directory: %w", err)
 	}
 
 	// Try single-agent detection first
 	result, err := agent.Detect(home)
 	if err == nil {
-		return result.InstallPath, nil
+		return []string{result.InstallPath}, nil
 	}
 
 	// Check for multi-agent scenario
 	agents := agent.DetectAll(home)
 	if len(agents) == 0 {
-		return "", fmt.Errorf("no known AI agent detected\n  hint: use --target <path> to specify the installation directory")
+		return nil, fmt.Errorf("no known AI agent detected\n  hint: use --target <path> to specify the installation directory")
 	}
 
 	// Multiple agents detected — prompt if stdin is TTY
@@ -175,14 +175,14 @@ func resolveInstallTarget(target string) (string, error) {
 		for i, a := range agents {
 			names[i] = a.Agent.String()
 		}
-		return "", fmt.Errorf("multiple AI agents detected (%s)\n  hint: use --target <path> to specify the installation directory",
+		return nil, fmt.Errorf("multiple AI agents detected (%s)\n  hint: use --target <path> to specify the installation directory",
 			strings.Join(names, ", "))
 	}
 
 	return promptAgentChoice(agents)
 }
 
-func promptAgentChoice(agents []agent.DetectResult) (string, error) {
+func promptAgentChoice(agents []agent.DetectResult) ([]string, error) {
 	fmt.Fprintf(os.Stderr, "\nMultiple AI agents detected. Where should skills be installed?\n\n")
 	for i, a := range agents {
 		fmt.Fprintf(os.Stderr, "  %d) %s (%s)\n", i+1, a.Agent.String(), a.InstallPath)
@@ -192,29 +192,28 @@ func promptAgentChoice(agents []agent.DetectResult) (string, error) {
 
 	scanner := bufio.NewScanner(os.Stdin)
 	if !scanner.Scan() {
-		return "", fmt.Errorf("no input received\n  hint: use --target <path> for non-interactive use")
+		return nil, fmt.Errorf("no input received\n  hint: use --target <path> for non-interactive use")
 	}
 
 	choice := strings.TrimSpace(scanner.Text())
 
-	// "Both" selection — use first agent's path (install to both happens at caller level)
+	// "Both" selection — return all agent paths
 	bothChoice := fmt.Sprintf("%d", len(agents)+1)
 	if choice == bothChoice {
-		// For "both", return a comma-separated list that the caller splits
 		paths := make([]string, len(agents))
 		for i, a := range agents {
 			paths[i] = a.InstallPath
 		}
-		return strings.Join(paths, ","), nil
+		return paths, nil
 	}
 
 	// Parse numeric choice
 	var idx int
 	if _, err := fmt.Sscanf(choice, "%d", &idx); err != nil || idx < 1 || idx > len(agents) {
-		return "", fmt.Errorf("invalid choice %q\n  hint: enter a number from 1 to %d", choice, len(agents)+1)
+		return nil, fmt.Errorf("invalid choice %q\n  hint: enter a number from 1 to %d", choice, len(agents)+1)
 	}
 
-	return agents[idx-1].InstallPath, nil
+	return []string{agents[idx-1].InstallPath}, nil
 }
 
 // printDependencyTree prints a formatted dependency tree to stderr.

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -174,12 +174,12 @@ func resolveInstallTargets(target string) ([]string, error) {
 }
 
 func promptAgentChoice(agents []agent.DetectResult, in io.Reader, errOut io.Writer) ([]string, error) {
-	fmt.Fprintf(errOut, "\nMultiple AI agents detected. Where should skills be installed?\n\n")
+	_, _ = fmt.Fprintf(errOut, "\nMultiple AI agents detected. Where should skills be installed?\n\n")
 	for i, a := range agents {
-		fmt.Fprintf(errOut, "  %d) %s (%s)\n", i+1, a.Agent.String(), a.InstallPath)
+		_, _ = fmt.Fprintf(errOut, "  %d) %s (%s)\n", i+1, a.Agent.String(), a.InstallPath)
 	}
-	fmt.Fprintf(errOut, "  %d) Both\n", len(agents)+1)
-	fmt.Fprintf(errOut, "\nChoice [1-%d]: ", len(agents)+1)
+	_, _ = fmt.Fprintf(errOut, "  %d) Both\n", len(agents)+1)
+	_, _ = fmt.Fprintf(errOut, "\nChoice [1-%d]: ", len(agents)+1)
 
 	scanner := bufio.NewScanner(in)
 	if !scanner.Scan() {
@@ -232,7 +232,7 @@ func printDependencyTree(cmd *cobra.Command, m *manifest.Manifest, result *resol
 		})
 	}
 
-	fmt.Fprintln(cmd.ErrOrStderr())
+	_, _ = fmt.Fprintln(cmd.ErrOrStderr())
 	ui.RenderTree(cmd.ErrOrStderr(), packageName, localSkills, deps)
 }
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -10,6 +10,7 @@ import (
 	"github.com/erdemtuna/craft/internal/agent"
 	"github.com/erdemtuna/craft/internal/fetch"
 	installlib "github.com/erdemtuna/craft/internal/install"
+	"github.com/erdemtuna/craft/internal/integrity"
 	"github.com/erdemtuna/craft/internal/manifest"
 	"github.com/erdemtuna/craft/internal/pinfile"
 	"github.com/erdemtuna/craft/internal/resolve"
@@ -96,6 +97,12 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	skillFiles, err := collectSkillFiles(fetcher, result)
 	if err != nil {
 		progress.Fail("Fetching failed")
+		return err
+	}
+
+	// Verify integrity of collected files against pinfile digests
+	if err := verifyIntegrity(result, skillFiles); err != nil {
+		progress.Fail("Integrity check failed")
 		return err
 	}
 
@@ -303,6 +310,41 @@ func collectSkillFiles(fetcher fetch.GitFetcher, result *resolve.ResolveResult) 
 	}
 
 	return skills, nil
+}
+
+// verifyIntegrity checks that the collected skill files match the integrity
+// digests stored in the pinfile. Returns an error if any dependency's files
+// produce a different digest than expected (indicating cache corruption).
+func verifyIntegrity(result *resolve.ResolveResult, skills map[string]map[string][]byte) error {
+	for _, dep := range result.Resolved {
+		pinEntry, ok := result.Pinfile.Resolved[dep.URL]
+		if !ok || pinEntry.Integrity == "" {
+			continue
+		}
+
+		// Reconstruct combined file map with original paths (matching resolver)
+		combined := make(map[string][]byte)
+		for i, skillName := range dep.Skills {
+			var prefix string
+			if i < len(dep.SkillPaths) && dep.SkillPaths[i] != "" {
+				prefix = dep.SkillPaths[i] + "/"
+			}
+
+			skillFiles, ok := skills[skillName]
+			if !ok {
+				continue
+			}
+			for relPath, content := range skillFiles {
+				combined[prefix+relPath] = content
+			}
+		}
+
+		got := integrity.Digest(combined)
+		if got != pinEntry.Integrity {
+			return fmt.Errorf("integrity mismatch for %s: expected %s, got %s (cache may be corrupted, try 'craft cache clean')", dep.URL, pinEntry.Integrity, got)
+		}
+	}
+	return nil
 }
 
 func countSkills(result *resolve.ResolveResult) int {

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,7 +13,9 @@ import (
 	"github.com/erdemtuna/craft/internal/manifest"
 	"github.com/erdemtuna/craft/internal/pinfile"
 	"github.com/erdemtuna/craft/internal/resolve"
+	"github.com/erdemtuna/craft/internal/ui"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var installTarget string
@@ -35,10 +38,12 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("getting working directory: %w", err)
 	}
 
+	progress := ui.NewProgress()
+
 	// Parse manifest
 	m, err := manifest.ParseFile(filepath.Join(root, "craft.yaml"))
 	if err != nil {
-		return fmt.Errorf("reading craft.yaml: %w", err)
+		return fmt.Errorf("reading craft.yaml: %w\n  hint: run `craft init` to create one", err)
 	}
 
 	if len(m.Dependencies) == 0 {
@@ -65,13 +70,16 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	fetcher := fetch.NewGoGitFetcher(cache)
 
 	// Resolve dependencies
+	progress.Start("Resolving dependencies...")
 	resolver := resolve.NewResolver(fetcher)
 	result, err := resolver.Resolve(m, resolve.ResolveOptions{
 		ExistingPinfile: existingPinfile,
 	})
 	if err != nil {
+		progress.Fail("Resolution failed")
 		return fmt.Errorf("resolution failed: %w", err)
 	}
+	progress.Update(fmt.Sprintf("Resolved %d dependency(ies)", len(result.Resolved)))
 
 	// Write pinfile atomically
 	if err := writePinfileAtomic(pfPath, result.Pinfile); err != nil {
@@ -85,18 +93,30 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	}
 
 	// Collect skill files for installation
+	total := len(result.Resolved)
+	for i, dep := range result.Resolved {
+		progress.UpdateCount("Fetching dependency", i+1, total)
+		_ = dep
+	}
 	skillFiles, err := collectSkillFiles(fetcher, result)
 	if err != nil {
+		progress.Fail("Fetching failed")
 		return err
 	}
 
 	// Install
+	progress.Update("Installing skills...")
 	if err := installlib.Install(targetPath, skillFiles); err != nil {
+		progress.Fail("Installation failed")
 		return fmt.Errorf("installation failed: %w", err)
 	}
 
-	cmd.Printf("Resolved %d dependency(ies), installed %d skill(s) to %s\n",
-		len(result.Resolved), countSkills(result), targetPath)
+	skillCount := countSkills(result)
+	progress.Done(fmt.Sprintf("Installed %d skill(s) from %d package(s) to %s",
+		skillCount, len(result.Resolved), targetPath))
+
+	// Print dependency tree to stderr
+	printDependencyTree(cmd, m, result)
 
 	return nil
 }
@@ -137,12 +157,93 @@ func resolveInstallTarget(target string) (string, error) {
 		return "", fmt.Errorf("determining home directory: %w", err)
 	}
 
+	// Try single-agent detection first
 	result, err := agent.Detect(home)
-	if err != nil {
-		return "", err
+	if err == nil {
+		return result.InstallPath, nil
 	}
 
-	return result.InstallPath, nil
+	// Check for multi-agent scenario
+	agents := agent.DetectAll(home)
+	if len(agents) == 0 {
+		return "", fmt.Errorf("no known AI agent detected\n  hint: use --target <path> to specify the installation directory")
+	}
+
+	// Multiple agents detected — prompt if stdin is TTY
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		names := make([]string, len(agents))
+		for i, a := range agents {
+			names[i] = a.Agent.String()
+		}
+		return "", fmt.Errorf("multiple AI agents detected (%s)\n  hint: use --target <path> to specify the installation directory",
+			strings.Join(names, ", "))
+	}
+
+	return promptAgentChoice(agents)
+}
+
+func promptAgentChoice(agents []agent.DetectResult) (string, error) {
+	fmt.Fprintf(os.Stderr, "\nMultiple AI agents detected. Where should skills be installed?\n\n")
+	for i, a := range agents {
+		fmt.Fprintf(os.Stderr, "  %d) %s (%s)\n", i+1, a.Agent.String(), a.InstallPath)
+	}
+	fmt.Fprintf(os.Stderr, "  %d) Both\n", len(agents)+1)
+	fmt.Fprintf(os.Stderr, "\nChoice [1-%d]: ", len(agents)+1)
+
+	scanner := bufio.NewScanner(os.Stdin)
+	if !scanner.Scan() {
+		return "", fmt.Errorf("no input received\n  hint: use --target <path> for non-interactive use")
+	}
+
+	choice := strings.TrimSpace(scanner.Text())
+
+	// "Both" selection — use first agent's path (install to both happens at caller level)
+	bothChoice := fmt.Sprintf("%d", len(agents)+1)
+	if choice == bothChoice {
+		// For "both", return a comma-separated list that the caller splits
+		paths := make([]string, len(agents))
+		for i, a := range agents {
+			paths[i] = a.InstallPath
+		}
+		return strings.Join(paths, ","), nil
+	}
+
+	// Parse numeric choice
+	var idx int
+	if _, err := fmt.Sscanf(choice, "%d", &idx); err != nil || idx < 1 || idx > len(agents) {
+		return "", fmt.Errorf("invalid choice %q\n  hint: enter a number from 1 to %d", choice, len(agents)+1)
+	}
+
+	return agents[idx-1].InstallPath, nil
+}
+
+// printDependencyTree prints a formatted dependency tree to stderr.
+func printDependencyTree(cmd *cobra.Command, m *manifest.Manifest, result *resolve.ResolveResult) {
+	packageName := m.Name
+	if m.Version != "" {
+		packageName += "@" + m.Version
+	}
+
+	// Extract local skill names from paths
+	var localSkills []string
+	for _, s := range m.Skills {
+		// Use the last path component as the display name
+		parts := strings.Split(strings.TrimRight(s, "/"), "/")
+		localSkills = append(localSkills, parts[len(parts)-1])
+	}
+
+	// Build dep nodes
+	var deps []ui.DepNode
+	for _, dep := range result.Resolved {
+		deps = append(deps, ui.DepNode{
+			Alias:  dep.Alias,
+			URL:    dep.URL,
+			Skills: dep.Skills,
+		})
+	}
+
+	fmt.Fprintln(cmd.ErrOrStderr())
+	ui.RenderTree(cmd.ErrOrStderr(), packageName, localSkills, deps)
 }
 
 func collectSkillFiles(fetcher fetch.GitFetcher, result *resolve.ResolveResult) (map[string]map[string][]byte, error) {

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -267,49 +267,34 @@ func collectSkillFiles(fetcher fetch.GitFetcher, result *resolve.ResolveResult) 
 
 		cloneURL := fetch.NormalizeCloneURL(parsed.PackageIdentity())
 
+		// Fetch tree once per dependency
+		allPaths, err := fetcher.ListTree(cloneURL, dep.Commit)
+		if err != nil {
+			return nil, fmt.Errorf("listing files for %s: %w", dep.URL, err)
+		}
+
 		for i, skillName := range dep.Skills {
 			var skillDir string
 			if i < len(dep.SkillPaths) {
 				skillDir = dep.SkillPaths[i]
 			}
 
-			// Read all files in skill directory
-			allPaths, err := fetcher.ListTree(cloneURL, dep.Commit)
-			if err != nil {
-				return nil, fmt.Errorf("listing files for %s: %w", skillName, err)
-			}
-
-			prefix := skillDir + "/"
-			if skillDir == "" {
-				prefix = ""
-			}
-			var filePaths []string
-			for _, p := range allPaths {
-				if prefix == "" || strings.HasPrefix(p, prefix) {
-					// For root-level skills, exclude infrastructure files
-					if prefix == "" && resolve.IsInfraFile(p) {
-						continue
-					}
-					filePaths = append(filePaths, p)
-				}
-			}
-
-			files, err := fetcher.ReadFiles(cloneURL, dep.Commit, filePaths)
+			files, err := resolve.CollectSkillDirFiles(fetcher, cloneURL, dep.Commit, allPaths, skillDir)
 			if err != nil {
 				return nil, fmt.Errorf("reading files for %s: %w", skillName, err)
 			}
 
 			// Remap paths to be relative to skill directory
-			mapped := make(map[string][]byte)
-			for p, content := range files {
-				relPath := p
-				if prefix != "" {
-					relPath = strings.TrimPrefix(p, prefix)
+			if skillDir != "" {
+				prefix := skillDir + "/"
+				mapped := make(map[string][]byte, len(files))
+				for p, content := range files {
+					mapped[strings.TrimPrefix(p, prefix)] = content
 				}
-				mapped[relPath] = content
+				files = mapped
 			}
 
-			skills[skillName] = mapped
+			skills[skillName] = files
 		}
 	}
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,7 +46,10 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	// Parse manifest
 	m, err := manifest.ParseFile(filepath.Join(root, "craft.yaml"))
 	if err != nil {
-		return fmt.Errorf("reading craft.yaml: %w\n  hint: run `craft init` to create one", err)
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("craft.yaml not found\n  hint: run `craft init` to create one")
+		}
+		return fmt.Errorf("reading craft.yaml: %w", err)
 	}
 
 	if len(m.Dependencies) == 0 {
@@ -60,15 +65,10 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	}
 
 	// Set up cache and fetcher
-	cacheRoot, err := fetch.DefaultCacheRoot()
+	fetcher, err := newFetcher()
 	if err != nil {
 		return err
 	}
-	cache, err := fetch.NewCache(cacheRoot)
-	if err != nil {
-		return err
-	}
-	fetcher := fetch.NewGoGitFetcher(cache)
 
 	// Resolve dependencies
 	progress.Start("Resolving dependencies...")
@@ -116,8 +116,12 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	}
 
 	skillCount := countSkills(result)
-	progress.Done(fmt.Sprintf("Installed %d skill(s) from %d package(s) to %s",
-		skillCount, len(result.Resolved), strings.Join(targetPaths, ", ")))
+	msg := fmt.Sprintf("Installed %d skill(s) from %d package(s) to %s",
+		skillCount, len(result.Resolved), strings.Join(targetPaths, ", "))
+	progress.Done(msg)
+	if !progress.IsTTY() {
+		cmd.Println(msg)
+	}
 
 	// Print dependency tree to stderr
 	printDependencyTree(cmd, m, result)
@@ -186,18 +190,18 @@ func resolveInstallTargets(target string) ([]string, error) {
 			strings.Join(names, ", "))
 	}
 
-	return promptAgentChoice(agents)
+	return promptAgentChoice(agents, os.Stdin, os.Stderr)
 }
 
-func promptAgentChoice(agents []agent.DetectResult) ([]string, error) {
-	fmt.Fprintf(os.Stderr, "\nMultiple AI agents detected. Where should skills be installed?\n\n")
+func promptAgentChoice(agents []agent.DetectResult, in io.Reader, errOut io.Writer) ([]string, error) {
+	fmt.Fprintf(errOut, "\nMultiple AI agents detected. Where should skills be installed?\n\n")
 	for i, a := range agents {
-		fmt.Fprintf(os.Stderr, "  %d) %s (%s)\n", i+1, a.Agent.String(), a.InstallPath)
+		fmt.Fprintf(errOut, "  %d) %s (%s)\n", i+1, a.Agent.String(), a.InstallPath)
 	}
-	fmt.Fprintf(os.Stderr, "  %d) Both\n", len(agents)+1)
-	fmt.Fprintf(os.Stderr, "\nChoice [1-%d]: ", len(agents)+1)
+	fmt.Fprintf(errOut, "  %d) Both\n", len(agents)+1)
+	fmt.Fprintf(errOut, "\nChoice [1-%d]: ", len(agents)+1)
 
-	scanner := bufio.NewScanner(os.Stdin)
+	scanner := bufio.NewScanner(in)
 	if !scanner.Scan() {
 		return nil, fmt.Errorf("no input received\n  hint: use --target <path> for non-interactive use")
 	}
@@ -353,4 +357,16 @@ func countSkills(result *resolve.ResolveResult) int {
 		count += len(dep.Skills)
 	}
 	return count
+}
+
+func newFetcher() (fetch.GitFetcher, error) {
+	cacheRoot, err := fetch.DefaultCacheRoot()
+	if err != nil {
+		return nil, err
+	}
+	cache, err := fetch.NewCache(cacheRoot)
+	if err != nil {
+		return nil, err
+	}
+	return fetch.NewGoGitFetcher(cache), nil
 }

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/erdemtuna/craft/internal/fetch"
+	"github.com/erdemtuna/craft/internal/integrity"
 	"github.com/erdemtuna/craft/internal/pinfile"
 	"github.com/erdemtuna/craft/internal/resolve"
 )
@@ -384,5 +385,113 @@ func TestResolveInstallTargets_ExplicitPath(t *testing.T) {
 	}
 	if len(got) != 1 || got[0] != want {
 		t.Errorf("resolveInstallTargets = %v, want [%q]", got, want)
+	}
+}
+
+func TestVerifyIntegrity_Pass(t *testing.T) {
+	// Build skill files matching what the resolver would produce
+	skillFiles := map[string]map[string][]byte{
+		"lint": {
+			"SKILL.md":    []byte("---\nname: lint\n---\n"),
+			"rules.yaml":  []byte("rules: []"),
+		},
+	}
+
+	// Compute the correct digest using original paths (with prefix)
+	combined := map[string][]byte{
+		"skills/lint/SKILL.md":   []byte("---\nname: lint\n---\n"),
+		"skills/lint/rules.yaml": []byte("rules: []"),
+	}
+	correctDigest := integrity.Digest(combined)
+
+	result := &resolve.ResolveResult{
+		Resolved: []resolve.ResolvedDep{
+			{
+				URL:        "github.com/org/repo@v1.0.0",
+				Commit:     "abc123",
+				Skills:     []string{"lint"},
+				SkillPaths: []string{"skills/lint"},
+			},
+		},
+		Pinfile: &pinfile.Pinfile{
+			PinVersion: 1,
+			Resolved: map[string]pinfile.ResolvedEntry{
+				"github.com/org/repo@v1.0.0": {
+					Commit:    "abc123",
+					Integrity: correctDigest,
+					Skills:    []string{"lint"},
+				},
+			},
+		},
+	}
+
+	if err := verifyIntegrity(result, skillFiles); err != nil {
+		t.Fatalf("verifyIntegrity returned unexpected error: %v", err)
+	}
+}
+
+func TestVerifyIntegrity_Mismatch(t *testing.T) {
+	// Skill files that don't match the pinfile digest (simulating cache poisoning)
+	skillFiles := map[string]map[string][]byte{
+		"lint": {
+			"SKILL.md": []byte("TAMPERED CONTENT"),
+		},
+	}
+
+	result := &resolve.ResolveResult{
+		Resolved: []resolve.ResolvedDep{
+			{
+				URL:        "github.com/org/repo@v1.0.0",
+				Commit:     "abc123",
+				Skills:     []string{"lint"},
+				SkillPaths: []string{"skills/lint"},
+			},
+		},
+		Pinfile: &pinfile.Pinfile{
+			PinVersion: 1,
+			Resolved: map[string]pinfile.ResolvedEntry{
+				"github.com/org/repo@v1.0.0": {
+					Commit:    "abc123",
+					Integrity: "sha256-originaldigest",
+					Skills:    []string{"lint"},
+				},
+			},
+		},
+	}
+
+	err := verifyIntegrity(result, skillFiles)
+	if err == nil {
+		t.Fatal("expected integrity mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "integrity mismatch") {
+		t.Errorf("expected 'integrity mismatch' in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "craft cache clean") {
+		t.Errorf("expected 'craft cache clean' hint in error, got: %v", err)
+	}
+}
+
+func TestVerifyIntegrity_SkipsMissingPinEntry(t *testing.T) {
+	skillFiles := map[string]map[string][]byte{
+		"lint": {"SKILL.md": []byte("content")},
+	}
+
+	result := &resolve.ResolveResult{
+		Resolved: []resolve.ResolvedDep{
+			{
+				URL:        "github.com/org/repo@v1.0.0",
+				Commit:     "abc123",
+				Skills:     []string{"lint"},
+				SkillPaths: []string{"skills/lint"},
+			},
+		},
+		Pinfile: &pinfile.Pinfile{
+			PinVersion: 1,
+			Resolved:   map[string]pinfile.ResolvedEntry{},
+		},
+	}
+
+	if err := verifyIntegrity(result, skillFiles); err != nil {
+		t.Fatalf("verifyIntegrity should skip deps without pinfile entry, got: %v", err)
 	}
 }

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -376,13 +376,13 @@ func TestCountSkills_Empty(t *testing.T) {
 	}
 }
 
-func TestResolveInstallTarget_ExplicitPath(t *testing.T) {
+func TestResolveInstallTargets_ExplicitPath(t *testing.T) {
 	want := "/custom/install/path"
-	got, err := resolveInstallTarget(want)
+	got, err := resolveInstallTargets(want)
 	if err != nil {
-		t.Fatalf("resolveInstallTarget error: %v", err)
+		t.Fatalf("resolveInstallTargets error: %v", err)
 	}
-	if got != want {
-		t.Errorf("resolveInstallTarget = %q, want %q", got, want)
+	if len(got) != 1 || got[0] != want {
+		t.Errorf("resolveInstallTargets = %v, want [%q]", got, want)
 	}
 }

--- a/internal/cli/remove.go
+++ b/internal/cli/remove.go
@@ -101,7 +101,7 @@ func runRemove(cmd *cobra.Command, args []string) error {
 
 		// Clean up orphaned skills from install target
 		if len(orphaned) > 0 {
-			targetPath, err := resolveInstallTarget(removeTarget)
+			targetPath, err := resolveInstallTargets(removeTarget)
 			if err != nil {
 				// If we can't determine target, just report what was orphaned
 				cmd.Printf("  orphaned skills (manual cleanup needed): %s\n", strings.Join(orphaned, ", "))
@@ -110,14 +110,29 @@ func runRemove(cmd *cobra.Command, args []string) error {
 
 			var cleaned []string
 			for _, skillName := range orphaned {
-				skillDir := filepath.Join(targetPath, skillName)
-				if _, err := os.Stat(skillDir); err == nil {
-					if err := os.RemoveAll(skillDir); err != nil {
-						cmd.PrintErrf("  warning: could not remove %s: %v\n", skillDir, err)
-					} else {
-						cleaned = append(cleaned, skillName)
+				for _, tp := range targetPath {
+					skillDir := filepath.Join(tp, skillName)
+					// Path traversal protection
+					absSkillDir, err := filepath.Abs(skillDir)
+					if err != nil {
+						continue
+					}
+					absTarget, err := filepath.Abs(tp)
+					if err != nil {
+						continue
+					}
+					if !strings.HasPrefix(absSkillDir, absTarget+string(filepath.Separator)) {
+						cmd.PrintErrf("  warning: skill name %q escapes target directory, skipping\n", skillName)
+						continue
+					}
+
+					if _, err := os.Stat(skillDir); err == nil {
+						if err := os.RemoveAll(skillDir); err != nil {
+							cmd.PrintErrf("  warning: could not remove %s: %v\n", skillDir, err)
+						}
 					}
 				}
+				cleaned = append(cleaned, skillName)
 			}
 
 			if len(cleaned) > 0 {

--- a/internal/cli/remove.go
+++ b/internal/cli/remove.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/erdemtuna/craft/internal/manifest"
+	"github.com/erdemtuna/craft/internal/pinfile"
+	"github.com/spf13/cobra"
+)
+
+var removeTarget string
+
+var removeCmd = &cobra.Command{
+	Use:   "remove <alias>",
+	Short: "Remove a dependency",
+	Long:  "Remove a dependency from craft.yaml, update craft.pin.yaml, and clean up orphaned skills from the install target.",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runRemove,
+}
+
+func init() {
+	removeCmd.Flags().StringVar(&removeTarget, "target", "", "Override agent auto-detection with a custom install path (for cleanup)")
+}
+
+func runRemove(cmd *cobra.Command, args []string) error {
+	alias := args[0]
+
+	root, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting working directory: %w", err)
+	}
+
+	// Parse manifest
+	manifestPath := filepath.Join(root, "craft.yaml")
+	m, err := manifest.ParseFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("reading craft.yaml: %w", err)
+	}
+
+	// Check alias exists
+	depURL, ok := m.Dependencies[alias]
+	if !ok {
+		available := availableAliases(m.Dependencies)
+		return fmt.Errorf("dependency %q not found in craft.yaml\n  hint: available aliases: %s", alias, available)
+	}
+
+	// Identify skills from the removed dependency (from pinfile)
+	pfPath := filepath.Join(root, "craft.pin.yaml")
+	pf, pfErr := pinfile.ParseFile(pfPath)
+
+	var removedSkills []string
+	if pfErr == nil {
+		// Find the pinfile entry for this dependency
+		if entry, ok := pf.Resolved[depURL]; ok {
+			removedSkills = entry.Skills
+		}
+	}
+
+	// Remove from manifest
+	delete(m.Dependencies, alias)
+
+	// Write updated manifest
+	if err := writeManifestAtomic(manifestPath, m); err != nil {
+		return err
+	}
+
+	cmd.Printf("Removed %q (%s)\n", alias, depURL)
+
+	// Update pinfile
+	if pfErr == nil {
+		// Collect all skills still needed by remaining dependencies
+		remainingSkills := make(map[string]bool)
+		for remainingAlias, remainingURL := range m.Dependencies {
+			_ = remainingAlias
+			if entry, ok := pf.Resolved[remainingURL]; ok {
+				for _, s := range entry.Skills {
+					remainingSkills[s] = true
+				}
+			}
+		}
+
+		// Remove the dep entry from pinfile
+		delete(pf.Resolved, depURL)
+
+		// Write updated pinfile
+		if err := writePinfileAtomic(pfPath, pf); err != nil {
+			return err
+		}
+
+		// Find orphaned skills (only in removed dep, not in any remaining dep)
+		var orphaned []string
+		for _, s := range removedSkills {
+			if !remainingSkills[s] {
+				orphaned = append(orphaned, s)
+			}
+		}
+
+		// Clean up orphaned skills from install target
+		if len(orphaned) > 0 {
+			targetPath, err := resolveInstallTarget(removeTarget)
+			if err != nil {
+				// If we can't determine target, just report what was orphaned
+				cmd.Printf("  orphaned skills (manual cleanup needed): %s\n", strings.Join(orphaned, ", "))
+				return nil
+			}
+
+			var cleaned []string
+			for _, skillName := range orphaned {
+				skillDir := filepath.Join(targetPath, skillName)
+				if _, err := os.Stat(skillDir); err == nil {
+					if err := os.RemoveAll(skillDir); err != nil {
+						cmd.PrintErrf("  warning: could not remove %s: %v\n", skillDir, err)
+					} else {
+						cleaned = append(cleaned, skillName)
+					}
+				}
+			}
+
+			if len(cleaned) > 0 {
+				cmd.Printf("  cleaned up %d orphaned skill(s): %s\n", len(cleaned), strings.Join(cleaned, ", "))
+			}
+		}
+	}
+
+	return nil
+}
+
+// availableAliases formats the available dependency aliases for error messages.
+func availableAliases(deps map[string]string) string {
+	if len(deps) == 0 {
+		return "(none)"
+	}
+	aliases := make([]string, 0, len(deps))
+	for k := range deps {
+		aliases = append(aliases, k)
+	}
+	sort.Strings(aliases)
+	return strings.Join(aliases, ", ")
+}

--- a/internal/cli/remove.go
+++ b/internal/cli/remove.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -38,6 +39,9 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	manifestPath := filepath.Join(root, "craft.yaml")
 	m, err := manifest.ParseFile(manifestPath)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("craft.yaml not found\n  hint: run `craft init` to create one")
+		}
 		return fmt.Errorf("reading craft.yaml: %w", err)
 	}
 
@@ -74,8 +78,7 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	if pfErr == nil {
 		// Collect all skills still needed by remaining dependencies
 		remainingSkills := make(map[string]bool)
-		for remainingAlias, remainingURL := range m.Dependencies {
-			_ = remainingAlias
+		for _, remainingURL := range m.Dependencies {
 			if entry, ok := pf.Resolved[remainingURL]; ok {
 				for _, s := range entry.Skills {
 					remainingSkills[s] = true
@@ -110,6 +113,7 @@ func runRemove(cmd *cobra.Command, args []string) error {
 
 			var cleaned []string
 			for _, skillName := range orphaned {
+				removed := false
 				for _, tp := range targetPath {
 					skillDir := filepath.Join(tp, skillName)
 					// Path traversal protection
@@ -129,10 +133,14 @@ func runRemove(cmd *cobra.Command, args []string) error {
 					if _, err := os.Stat(skillDir); err == nil {
 						if err := os.RemoveAll(skillDir); err != nil {
 							cmd.PrintErrf("  warning: could not remove %s: %v\n", skillDir, err)
+						} else {
+							removed = true
 						}
 					}
 				}
-				cleaned = append(cleaned, skillName)
+				if removed {
+					cleaned = append(cleaned, skillName)
+				}
 			}
 
 			if len(cleaned) > 0 {

--- a/internal/cli/remove_test.go
+++ b/internal/cli/remove_test.go
@@ -1,0 +1,252 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunRemove_ExistingDep(t *testing.T) {
+	dir := t.TempDir()
+
+	manifestContent := `schema_version: 1
+name: test-pkg
+version: 0.1.0
+skills:
+  - ./skills/s
+dependencies:
+  my-dep: github.com/org/repo@v1.0.0
+  other: github.com/org/other@v2.0.0
+`
+	os.WriteFile(filepath.Join(dir, "craft.yaml"), []byte(manifestContent), 0644)
+	os.MkdirAll(filepath.Join(dir, "skills", "s"), 0755)
+	os.WriteFile(filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"), 0644)
+
+	// Create pinfile with skills
+	pinContent := `pin_version: 1
+resolved:
+  github.com/org/repo@v1.0.0:
+    commit: abc123
+    integrity: sha256-test
+    skills:
+      - repo-skill
+  github.com/org/other@v2.0.0:
+    commit: def456
+    integrity: sha256-test2
+    skills:
+      - other-skill
+`
+	os.WriteFile(filepath.Join(dir, "craft.pin.yaml"), []byte(pinContent), 0644)
+
+	// Create installed skill directory
+	targetDir := filepath.Join(dir, "installed")
+	os.MkdirAll(filepath.Join(targetDir, "repo-skill"), 0755)
+	os.WriteFile(filepath.Join(targetDir, "repo-skill", "SKILL.md"), []byte("skill"), 0644)
+
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(dir)
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"remove", "--target", targetDir, "my-dep"})
+	err := rootCmd.Execute()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Removed") {
+		t.Errorf("expected 'Removed' message, got: %s", output)
+	}
+
+	// Verify manifest updated
+	updated, _ := os.ReadFile(filepath.Join(dir, "craft.yaml"))
+	if strings.Contains(string(updated), "my-dep") {
+		t.Error("manifest should not contain removed dep")
+	}
+	if !strings.Contains(string(updated), "other") {
+		t.Error("manifest should still contain other dep")
+	}
+
+	// Verify pinfile updated
+	updatedPin, _ := os.ReadFile(filepath.Join(dir, "craft.pin.yaml"))
+	if strings.Contains(string(updatedPin), "github.com/org/repo@v1.0.0") {
+		t.Error("pinfile should not contain removed dep")
+	}
+
+	// Verify orphaned skill cleaned up
+	if _, err := os.Stat(filepath.Join(targetDir, "repo-skill")); err == nil {
+		t.Error("orphaned skill directory should have been removed")
+	}
+}
+
+func TestRunRemove_NonExistentAlias(t *testing.T) {
+	dir := t.TempDir()
+
+	manifestContent := `schema_version: 1
+name: test-pkg
+version: 0.1.0
+skills:
+  - ./skills/s
+dependencies:
+  real-dep: github.com/org/repo@v1.0.0
+`
+	os.WriteFile(filepath.Join(dir, "craft.yaml"), []byte(manifestContent), 0644)
+	os.MkdirAll(filepath.Join(dir, "skills", "s"), 0755)
+	os.WriteFile(filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"), 0644)
+
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(dir)
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"remove", "nonexistent"})
+	err := rootCmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected error for non-existent alias")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "real-dep") {
+		t.Errorf("expected available aliases in error, got: %v", err)
+	}
+}
+
+func TestRunRemove_SharedSkillRetained(t *testing.T) {
+	dir := t.TempDir()
+
+	manifestContent := `schema_version: 1
+name: test-pkg
+version: 0.1.0
+skills:
+  - ./skills/s
+dependencies:
+  dep-a: github.com/org/a@v1.0.0
+  dep-b: github.com/org/b@v1.0.0
+`
+	os.WriteFile(filepath.Join(dir, "craft.yaml"), []byte(manifestContent), 0644)
+	os.MkdirAll(filepath.Join(dir, "skills", "s"), 0755)
+	os.WriteFile(filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"), 0644)
+
+	// Both deps provide "shared-skill", dep-a also provides "unique-a"
+	pinContent := `pin_version: 1
+resolved:
+  github.com/org/a@v1.0.0:
+    commit: aaa
+    integrity: sha256-a
+    skills:
+      - shared-skill
+      - unique-a
+  github.com/org/b@v1.0.0:
+    commit: bbb
+    integrity: sha256-b
+    skills:
+      - shared-skill
+`
+	os.WriteFile(filepath.Join(dir, "craft.pin.yaml"), []byte(pinContent), 0644)
+
+	// Create installed skill directories
+	targetDir := filepath.Join(dir, "installed")
+	os.MkdirAll(filepath.Join(targetDir, "shared-skill"), 0755)
+	os.MkdirAll(filepath.Join(targetDir, "unique-a"), 0755)
+
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(dir)
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"remove", "--target", targetDir, "dep-a"})
+	err := rootCmd.Execute()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// shared-skill should be retained (dep-b still provides it)
+	if _, err := os.Stat(filepath.Join(targetDir, "shared-skill")); err != nil {
+		t.Error("shared skill should have been retained")
+	}
+
+	// unique-a should be cleaned up
+	if _, err := os.Stat(filepath.Join(targetDir, "unique-a")); err == nil {
+		t.Error("unique-a should have been removed")
+	}
+}
+
+func TestRunRemove_LastDependency(t *testing.T) {
+	dir := t.TempDir()
+
+	manifestContent := `schema_version: 1
+name: test-pkg
+version: 0.1.0
+skills:
+  - ./skills/s
+dependencies:
+  only-dep: github.com/org/repo@v1.0.0
+`
+	os.WriteFile(filepath.Join(dir, "craft.yaml"), []byte(manifestContent), 0644)
+	os.MkdirAll(filepath.Join(dir, "skills", "s"), 0755)
+	os.WriteFile(filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"), 0644)
+
+	pinContent := `pin_version: 1
+resolved:
+  github.com/org/repo@v1.0.0:
+    commit: abc
+    integrity: sha256-x
+    skills:
+      - the-skill
+`
+	os.WriteFile(filepath.Join(dir, "craft.pin.yaml"), []byte(pinContent), 0644)
+
+	targetDir := filepath.Join(dir, "installed")
+	os.MkdirAll(filepath.Join(targetDir, "the-skill"), 0755)
+
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(dir)
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"remove", "--target", targetDir, "only-dep"})
+	err := rootCmd.Execute()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify manifest has no dependencies
+	updated, _ := os.ReadFile(filepath.Join(dir, "craft.yaml"))
+	if strings.Contains(string(updated), "dependencies") {
+		t.Error("manifest should have no dependencies section after removing last dep")
+	}
+}
+
+func TestAvailableAliases(t *testing.T) {
+	deps := map[string]string{
+		"zebra": "z",
+		"alpha": "a",
+	}
+	got := availableAliases(deps)
+	if got != "alpha, zebra" {
+		t.Errorf("expected sorted aliases, got: %s", got)
+	}
+}
+
+func TestAvailableAliases_Empty(t *testing.T) {
+	got := availableAliases(nil)
+	if got != "(none)" {
+		t.Errorf("expected '(none)', got: %s", got)
+	}
+}

--- a/internal/cli/remove_test.go
+++ b/internal/cli/remove_test.go
@@ -20,9 +20,9 @@ dependencies:
   my-dep: github.com/org/repo@v1.0.0
   other: github.com/org/other@v2.0.0
 `
-	os.WriteFile(filepath.Join(dir, "craft.yaml"), []byte(manifestContent), 0644)
-	os.MkdirAll(filepath.Join(dir, "skills", "s"), 0755)
-	os.WriteFile(filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"), 0644)
+	_ = os.WriteFile(filepath.Join(dir, "craft.yaml"), []byte(manifestContent), 0644)
+	_ = os.MkdirAll(filepath.Join(dir, "skills", "s"), 0755)
+	_ = os.WriteFile(filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"), 0644)
 
 	// Create pinfile with skills
 	pinContent := `pin_version: 1
@@ -38,16 +38,16 @@ resolved:
     skills:
       - other-skill
 `
-	os.WriteFile(filepath.Join(dir, "craft.pin.yaml"), []byte(pinContent), 0644)
+	_ = os.WriteFile(filepath.Join(dir, "craft.pin.yaml"), []byte(pinContent), 0644)
 
 	// Create installed skill directory
 	targetDir := filepath.Join(dir, "installed")
-	os.MkdirAll(filepath.Join(targetDir, "repo-skill"), 0755)
-	os.WriteFile(filepath.Join(targetDir, "repo-skill", "SKILL.md"), []byte("skill"), 0644)
+	_ = os.MkdirAll(filepath.Join(targetDir, "repo-skill"), 0755)
+	_ = os.WriteFile(filepath.Join(targetDir, "repo-skill", "SKILL.md"), []byte("skill"), 0644)
 
 	oldWd, _ := os.Getwd()
-	defer os.Chdir(oldWd)
-	os.Chdir(dir)
+	defer func() { _ = os.Chdir(oldWd) }()
+	_ = os.Chdir(dir)
 
 	var buf bytes.Buffer
 	rootCmd.SetOut(&buf)
@@ -96,13 +96,13 @@ skills:
 dependencies:
   real-dep: github.com/org/repo@v1.0.0
 `
-	os.WriteFile(filepath.Join(dir, "craft.yaml"), []byte(manifestContent), 0644)
-	os.MkdirAll(filepath.Join(dir, "skills", "s"), 0755)
-	os.WriteFile(filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"), 0644)
+	_ = os.WriteFile(filepath.Join(dir, "craft.yaml"), []byte(manifestContent), 0644)
+	_ = os.MkdirAll(filepath.Join(dir, "skills", "s"), 0755)
+	_ = os.WriteFile(filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"), 0644)
 
 	oldWd, _ := os.Getwd()
-	defer os.Chdir(oldWd)
-	os.Chdir(dir)
+	defer func() { _ = os.Chdir(oldWd) }()
+	_ = os.Chdir(dir)
 
 	var buf bytes.Buffer
 	rootCmd.SetOut(&buf)
@@ -133,9 +133,9 @@ dependencies:
   dep-a: github.com/org/a@v1.0.0
   dep-b: github.com/org/b@v1.0.0
 `
-	os.WriteFile(filepath.Join(dir, "craft.yaml"), []byte(manifestContent), 0644)
-	os.MkdirAll(filepath.Join(dir, "skills", "s"), 0755)
-	os.WriteFile(filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"), 0644)
+	_ = os.WriteFile(filepath.Join(dir, "craft.yaml"), []byte(manifestContent), 0644)
+	_ = os.MkdirAll(filepath.Join(dir, "skills", "s"), 0755)
+	_ = os.WriteFile(filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"), 0644)
 
 	// Both deps provide "shared-skill", dep-a also provides "unique-a"
 	pinContent := `pin_version: 1
@@ -152,16 +152,16 @@ resolved:
     skills:
       - shared-skill
 `
-	os.WriteFile(filepath.Join(dir, "craft.pin.yaml"), []byte(pinContent), 0644)
+	_ = os.WriteFile(filepath.Join(dir, "craft.pin.yaml"), []byte(pinContent), 0644)
 
 	// Create installed skill directories
 	targetDir := filepath.Join(dir, "installed")
-	os.MkdirAll(filepath.Join(targetDir, "shared-skill"), 0755)
-	os.MkdirAll(filepath.Join(targetDir, "unique-a"), 0755)
+	_ = os.MkdirAll(filepath.Join(targetDir, "shared-skill"), 0755)
+	_ = os.MkdirAll(filepath.Join(targetDir, "unique-a"), 0755)
 
 	oldWd, _ := os.Getwd()
-	defer os.Chdir(oldWd)
-	os.Chdir(dir)
+	defer func() { _ = os.Chdir(oldWd) }()
+	_ = os.Chdir(dir)
 
 	var buf bytes.Buffer
 	rootCmd.SetOut(&buf)
@@ -195,9 +195,9 @@ skills:
 dependencies:
   only-dep: github.com/org/repo@v1.0.0
 `
-	os.WriteFile(filepath.Join(dir, "craft.yaml"), []byte(manifestContent), 0644)
-	os.MkdirAll(filepath.Join(dir, "skills", "s"), 0755)
-	os.WriteFile(filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"), 0644)
+	_ = os.WriteFile(filepath.Join(dir, "craft.yaml"), []byte(manifestContent), 0644)
+	_ = os.MkdirAll(filepath.Join(dir, "skills", "s"), 0755)
+	_ = os.WriteFile(filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"), 0644)
 
 	pinContent := `pin_version: 1
 resolved:
@@ -207,14 +207,14 @@ resolved:
     skills:
       - the-skill
 `
-	os.WriteFile(filepath.Join(dir, "craft.pin.yaml"), []byte(pinContent), 0644)
+	_ = os.WriteFile(filepath.Join(dir, "craft.pin.yaml"), []byte(pinContent), 0644)
 
 	targetDir := filepath.Join(dir, "installed")
-	os.MkdirAll(filepath.Join(targetDir, "the-skill"), 0755)
+	_ = os.MkdirAll(filepath.Join(targetDir, "the-skill"), 0755)
 
 	oldWd, _ := os.Getwd()
-	defer os.Chdir(oldWd)
-	os.Chdir(dir)
+	defer func() { _ = os.Chdir(oldWd) }()
+	_ = os.Chdir(dir)
 
 	var buf bytes.Buffer
 	rootCmd.SetOut(&buf)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -22,6 +22,7 @@ func init() {
 	rootCmd.AddCommand(installCmd)
 	rootCmd.AddCommand(updateCmd)
 	rootCmd.AddCommand(addCmd)
+	rootCmd.AddCommand(removeCmd)
 	rootCmd.AddCommand(cacheCmd)
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -21,6 +21,7 @@ func init() {
 	rootCmd.AddCommand(validateCmd)
 	rootCmd.AddCommand(installCmd)
 	rootCmd.AddCommand(updateCmd)
+	rootCmd.AddCommand(addCmd)
 	rootCmd.AddCommand(cacheCmd)
 }
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -95,7 +95,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		if latest != parsed.GitTag() {
+		if semver.Compare(strings.TrimPrefix(latest, "v"), parsed.Version) > 0 {
 			newURL := parsed.WithVersion(latest)
 			m.Dependencies[alias] = newURL
 			updated = true

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -41,7 +42,10 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	manifestPath := filepath.Join(root, "craft.yaml")
 	m, err := manifest.ParseFile(manifestPath)
 	if err != nil {
-		return fmt.Errorf("reading craft.yaml: %w\n  hint: run `craft init` to create one", err)
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("craft.yaml not found\n  hint: run `craft init` to create one")
+		}
+		return fmt.Errorf("reading craft.yaml: %w", err)
 	}
 
 	if len(m.Dependencies) == 0 {
@@ -50,15 +54,10 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	// Set up cache and fetcher
-	cacheRoot, err := fetch.DefaultCacheRoot()
+	fetcher, err := newFetcher()
 	if err != nil {
 		return err
 	}
-	cache, err := fetch.NewCache(cacheRoot)
-	if err != nil {
-		return err
-	}
-	fetcher := fetch.NewGoGitFetcher(cache)
 
 	// Determine which deps to update
 	var targetAlias string
@@ -105,7 +104,11 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if !updated {
-		progress.Done("All dependencies are up to date.")
+		msg := "All dependencies are up to date."
+		progress.Done(msg)
+		if !progress.IsTTY() {
+			cmd.Println(msg)
+		}
 		return nil
 	}
 
@@ -165,7 +168,11 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	skillCount := countSkills(result)
-	progress.Done(fmt.Sprintf("Updated and installed %d skill(s) to %s", skillCount, strings.Join(targetPaths, ", ")))
+	msg := fmt.Sprintf("Updated and installed %d skill(s) to %s", skillCount, strings.Join(targetPaths, ", "))
+	progress.Done(msg)
+	if !progress.IsTTY() {
+		cmd.Println(msg)
+	}
 
 	// Print dependency tree to stderr
 	printDependencyTree(cmd, m, result)

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -109,12 +109,8 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Write updated manifest atomically
-	if err := writeManifestAtomic(manifestPath, m); err != nil {
-		return err
-	}
-
-	// Now run install with the updated manifest (force re-resolve)
+	// Resolve before writing anything to disk — if resolution fails,
+	// neither manifest nor pinfile is modified.
 	progress.Update("Resolving updated dependencies...")
 	forceResolve := make(map[string]bool)
 	for alias, depURL := range m.Dependencies {
@@ -141,6 +137,11 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := writePinfileAtomic(pfPath, result.Pinfile); err != nil {
+		return err
+	}
+
+	// Write updated manifest only after resolution and pinfile write succeed
+	if err := writeManifestAtomic(manifestPath, m); err != nil {
 		return err
 	}
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -181,29 +182,9 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 }
 
 func writeManifestAtomic(path string, m *manifest.Manifest) error {
-	tmpPath := path + ".tmp"
-	f, err := os.Create(tmpPath)
-	if err != nil {
-		return fmt.Errorf("creating manifest: %w", err)
-	}
-
-	if err := manifest.Write(m, f); err != nil {
-		_ = f.Close()
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("writing manifest: %w", err)
-	}
-
-	if err := f.Close(); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("writing manifest: %w", err)
-	}
-
-	if err := os.Rename(tmpPath, path); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("saving manifest: %w", err)
-	}
-
-	return nil
+	return writeAtomic(path, func(w io.Writer) error {
+		return manifest.Write(m, w)
+	})
 }
 
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -11,6 +11,7 @@ import (
 	"github.com/erdemtuna/craft/internal/pinfile"
 	"github.com/erdemtuna/craft/internal/resolve"
 	"github.com/erdemtuna/craft/internal/semver"
+	"github.com/erdemtuna/craft/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -34,10 +35,12 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("getting working directory: %w", err)
 	}
 
+	progress := ui.NewProgress()
+
 	manifestPath := filepath.Join(root, "craft.yaml")
 	m, err := manifest.ParseFile(manifestPath)
 	if err != nil {
-		return fmt.Errorf("reading craft.yaml: %w", err)
+		return fmt.Errorf("reading craft.yaml: %w\n  hint: run `craft init` to create one", err)
 	}
 
 	if len(m.Dependencies) == 0 {
@@ -61,11 +64,13 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		targetAlias = args[0]
 		if _, ok := m.Dependencies[targetAlias]; !ok {
-			return fmt.Errorf("dependency %q not found in craft.yaml", targetAlias)
+			return fmt.Errorf("dependency %q not found in craft.yaml\n  hint: available aliases: %s",
+				targetAlias, availableAliases(m.Dependencies))
 		}
 	}
 
 	// Find latest versions for targeted deps
+	progress.Start("Checking for updates...")
 	updated := false
 	for alias, depURL := range m.Dependencies {
 		if targetAlias != "" && alias != targetAlias {
@@ -81,7 +86,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 		tags, err := fetcher.ListTags(cloneURL)
 		if err != nil {
-			return fmt.Errorf("listing tags for %s: %w", depURL, err)
+			return fmt.Errorf("listing tags for %s: %w\n  hint: check your connection or set GITHUB_TOKEN for private repos", depURL, err)
 		}
 
 		latest := semver.FindLatest(tags)
@@ -99,7 +104,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if !updated {
-		cmd.Println("All dependencies are up to date.")
+		progress.Done("All dependencies are up to date.")
 		return nil
 	}
 
@@ -109,6 +114,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	// Now run install with the updated manifest (force re-resolve)
+	progress.Update("Resolving updated dependencies...")
 	forceResolve := make(map[string]bool)
 	for alias, depURL := range m.Dependencies {
 		if targetAlias == "" || alias == targetAlias {
@@ -129,6 +135,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		ForceResolve:    forceResolve,
 	})
 	if err != nil {
+		progress.Fail("Resolution failed")
 		return fmt.Errorf("resolution failed: %w", err)
 	}
 
@@ -137,6 +144,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	// Install
+	progress.Update("Installing skills...")
 	targetPath, err := resolveInstallTarget(updateTarget)
 	if err != nil {
 		return err
@@ -148,10 +156,15 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := installlib.Install(targetPath, skillFiles); err != nil {
+		progress.Fail("Installation failed")
 		return fmt.Errorf("installation failed: %w", err)
 	}
 
-	cmd.Printf("Updated and installed %d skill(s) to %s\n", countSkills(result), targetPath)
+	skillCount := countSkills(result)
+	progress.Done(fmt.Sprintf("Updated and installed %d skill(s) to %s", skillCount, targetPath))
+
+	// Print dependency tree to stderr
+	printDependencyTree(cmd, m, result)
 
 	return nil
 }

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/erdemtuna/craft/internal/fetch"
 	installlib "github.com/erdemtuna/craft/internal/install"
@@ -145,7 +146,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 	// Install
 	progress.Update("Installing skills...")
-	targetPath, err := resolveInstallTarget(updateTarget)
+	targetPaths, err := resolveInstallTargets(updateTarget)
 	if err != nil {
 		return err
 	}
@@ -155,13 +156,15 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := installlib.Install(targetPath, skillFiles); err != nil {
-		progress.Fail("Installation failed")
-		return fmt.Errorf("installation failed: %w", err)
+	for _, targetPath := range targetPaths {
+		if err := installlib.Install(targetPath, skillFiles); err != nil {
+			progress.Fail("Installation failed")
+			return fmt.Errorf("installation failed: %w", err)
+		}
 	}
 
 	skillCount := countSkills(result)
-	progress.Done(fmt.Sprintf("Updated and installed %d skill(s) to %s", skillCount, targetPath))
+	progress.Done(fmt.Sprintf("Updated and installed %d skill(s) to %s", skillCount, strings.Join(targetPaths, ", ")))
 
 	// Print dependency tree to stderr
 	printDependencyTree(cmd, m, result)

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -69,6 +69,32 @@ func TestCompareParts(t *testing.T) {
 	}
 }
 
+func TestUpdateSkipsDowngrade(t *testing.T) {
+	// Simulate the update logic: if the remote "latest" tag is older than
+	// the currently pinned version, no update should happen.
+	currentVersion := "2.0.0"
+	latestTag := "v1.5.0" // older than current — should be skipped
+
+	latestVersion := strings.TrimPrefix(latestTag, "v")
+	if semver.Compare(latestVersion, currentVersion) > 0 {
+		t.Errorf("downgrade should be skipped: latest %s is not newer than current %s", latestTag, currentVersion)
+	}
+
+	// Verify that a genuine upgrade is still accepted
+	upgradeTag := "v3.0.0"
+	upgradeVersion := strings.TrimPrefix(upgradeTag, "v")
+	if semver.Compare(upgradeVersion, currentVersion) <= 0 {
+		t.Errorf("upgrade should be accepted: latest %s should be newer than current %s", upgradeTag, currentVersion)
+	}
+
+	// Equal versions should not trigger an update either
+	sameTag := "v2.0.0"
+	sameVersion := strings.TrimPrefix(sameTag, "v")
+	if semver.Compare(sameVersion, currentVersion) > 0 {
+		t.Errorf("same version should not trigger update: %s == %s", sameTag, currentVersion)
+	}
+}
+
 func TestWriteManifestAtomic(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "craft.yaml")

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -33,7 +33,7 @@ var validateCmd = &cobra.Command{
 		for _, e := range result.Errors {
 			fmt.Fprintf(os.Stderr, "error: %s\n", e.Error())
 			if e.Suggestion != "" {
-				fmt.Fprintf(os.Stderr, "  fix: %s\n", e.Suggestion)
+				fmt.Fprintf(os.Stderr, "  hint: %s\n", e.Suggestion)
 			}
 		}
 

--- a/internal/fetch/auth.go
+++ b/internal/fetch/auth.go
@@ -2,9 +2,11 @@ package fetch
 
 import (
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
@@ -13,6 +15,16 @@ import (
 
 // gitHubHosts lists hosts where GITHUB_TOKEN may be sent.
 var gitHubHosts = []string{"github.com"}
+
+// wellKnownForges lists hosts that are trusted by default for CRAFT_TOKEN
+// when CRAFT_TOKEN_HOSTS is not set.
+var wellKnownForges = []string{"github.com", "gitlab.com", "bitbucket.org"}
+
+var craftTokenWarning sync.Once
+
+// warnWriter is the writer used for warnings (stderr by default).
+// Overridden in tests to capture output.
+var warnWriter io.Writer = os.Stderr
 
 // isGitHubHost returns true if the URL points to a known GitHub host.
 func isGitHubHost(rawURL string) bool {
@@ -29,19 +41,58 @@ func isGitHubHost(rawURL string) bool {
 	return false
 }
 
+// isTrustedHost returns true if rawURL points to a host that should receive
+// CRAFT_TOKEN. When CRAFT_TOKEN_HOSTS is set, only those hosts are trusted.
+// Otherwise, well-known forges are trusted and a one-time warning is emitted
+// for any other host.
+func isTrustedHost(rawURL string) bool {
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Host == "" {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+
+	// If CRAFT_TOKEN_HOSTS is set, use it as an explicit allowlist.
+	if allowlist := os.Getenv("CRAFT_TOKEN_HOSTS"); allowlist != "" {
+		for _, h := range strings.Split(allowlist, ",") {
+			if strings.TrimSpace(strings.ToLower(h)) == host {
+				return true
+			}
+		}
+		return false
+	}
+
+	// No allowlist — check well-known forges.
+	for _, h := range wellKnownForges {
+		if host == h {
+			return true
+		}
+	}
+
+	// Unknown host without allowlist: warn once, then allow (backward compat).
+	craftTokenWarning.Do(func() {
+		fmt.Fprintf(warnWriter,
+			"warning: CRAFT_TOKEN is being sent to %q which is not a well-known forge.\n"+
+				"  Set CRAFT_TOKEN_HOSTS to restrict token to trusted hosts.\n", host)
+	})
+	return true
+}
+
 // Auth resolves authentication for git operations.
 // Checks environment tokens first (CRAFT_TOKEN > GITHUB_TOKEN),
 // then falls back to SSH agent.
 //
-// CRAFT_TOKEN is sent to any host (user explicitly configured it for craft).
+// CRAFT_TOKEN is scoped to trusted hosts: well-known forges by default, or
+// hosts listed in CRAFT_TOKEN_HOSTS when set. A one-time warning is emitted
+// when the token is sent to an unknown host without an explicit allowlist.
 // GITHUB_TOKEN is only sent to known GitHub hosts to prevent token leakage
 // to untrusted third-party servers via transitive dependencies.
 //
 // Returns nil auth (anonymous) if no credentials are found — the caller
 // should attempt the operation and wrap any auth errors with suggestions.
 func Auth(url string) transport.AuthMethod {
-	// CRAFT_TOKEN: universal, sent to any host
-	if token := os.Getenv("CRAFT_TOKEN"); token != "" {
+	// CRAFT_TOKEN: scoped to trusted hosts
+	if token := os.Getenv("CRAFT_TOKEN"); token != "" && isTrustedHost(url) {
 		return &http.BasicAuth{
 			Username: "x-access-token",
 			Password: token,

--- a/internal/fetch/auth.go
+++ b/internal/fetch/auth.go
@@ -71,7 +71,7 @@ func isTrustedHost(rawURL string) bool {
 
 	// Unknown host without allowlist: warn once, then allow (backward compat).
 	craftTokenWarning.Do(func() {
-		fmt.Fprintf(warnWriter,
+		_, _ = fmt.Fprintf(warnWriter,
 			"warning: CRAFT_TOKEN is being sent to %q which is not a well-known forge.\n"+
 				"  Set CRAFT_TOKEN_HOSTS to restrict token to trusted hosts.\n", host)
 	})

--- a/internal/fetch/auth_test.go
+++ b/internal/fetch/auth_test.go
@@ -1,16 +1,26 @@
 package fetch
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 )
 
+// resetWarningState resets the one-time warning guard between tests.
+func resetWarningState(t *testing.T) {
+	t.Helper()
+	craftTokenWarning = sync.Once{}
+}
+
 func TestAuthCraftTokenPrecedence(t *testing.T) {
+	resetWarningState(t)
 	t.Setenv("CRAFT_TOKEN", "craft-secret")
 	t.Setenv("GITHUB_TOKEN", "github-secret")
+	t.Setenv("CRAFT_TOKEN_HOSTS", "")
 
 	auth := Auth("https://github.com/org/repo.git")
 	if auth == nil {
@@ -26,8 +36,10 @@ func TestAuthCraftTokenPrecedence(t *testing.T) {
 }
 
 func TestAuthGitHubTokenFallback(t *testing.T) {
+	resetWarningState(t)
 	t.Setenv("CRAFT_TOKEN", "")
 	t.Setenv("GITHUB_TOKEN", "github-secret")
+	t.Setenv("CRAFT_TOKEN_HOSTS", "")
 
 	auth := Auth("https://github.com/org/repo.git")
 	if auth == nil {
@@ -36,8 +48,10 @@ func TestAuthGitHubTokenFallback(t *testing.T) {
 }
 
 func TestAuthNoTokensReturnsNil(t *testing.T) {
+	resetWarningState(t)
 	t.Setenv("CRAFT_TOKEN", "")
 	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("CRAFT_TOKEN_HOSTS", "")
 
 	auth := Auth("https://github.com/org/repo.git")
 	if auth != nil {
@@ -46,8 +60,10 @@ func TestAuthNoTokensReturnsNil(t *testing.T) {
 }
 
 func TestAuthGitHubTokenNotSentToEvilHost(t *testing.T) {
+	resetWarningState(t)
 	t.Setenv("CRAFT_TOKEN", "")
 	t.Setenv("GITHUB_TOKEN", "github-secret")
+	t.Setenv("CRAFT_TOKEN_HOSTS", "")
 
 	auth := Auth("https://evil.com/attacker/repo.git")
 	if auth != nil {
@@ -55,13 +71,48 @@ func TestAuthGitHubTokenNotSentToEvilHost(t *testing.T) {
 	}
 }
 
-func TestAuthCraftTokenSentToAnyHost(t *testing.T) {
+func TestAuthCraftTokenSentToKnownForge(t *testing.T) {
+	resetWarningState(t)
 	t.Setenv("CRAFT_TOKEN", "craft-secret")
 	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("CRAFT_TOKEN_HOSTS", "")
+
+	for _, host := range []string{"github.com", "gitlab.com", "bitbucket.org"} {
+		auth := Auth("https://" + host + "/org/repo.git")
+		if auth == nil {
+			t.Fatalf("CRAFT_TOKEN should be sent to well-known forge %s", host)
+		}
+		basic, ok := auth.(*http.BasicAuth)
+		if !ok {
+			t.Fatalf("Expected *http.BasicAuth for %s", host)
+		}
+		if basic.Password != "craft-secret" {
+			t.Errorf("Expected craft-secret for %s, got %q", host, basic.Password)
+		}
+	}
+}
+
+func TestAuthCraftTokenNotSentToUntrustedHostWithAllowlist(t *testing.T) {
+	resetWarningState(t)
+	t.Setenv("CRAFT_TOKEN", "craft-secret")
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("CRAFT_TOKEN_HOSTS", "github.com,internal.example.com")
 
 	auth := Auth("https://evil.com/attacker/repo.git")
+	if auth != nil {
+		t.Error("CRAFT_TOKEN must not be sent to hosts outside CRAFT_TOKEN_HOSTS")
+	}
+}
+
+func TestAuthCraftTokenSentToAllowlistedHost(t *testing.T) {
+	resetWarningState(t)
+	t.Setenv("CRAFT_TOKEN", "craft-secret")
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("CRAFT_TOKEN_HOSTS", "github.com,internal.example.com")
+
+	auth := Auth("https://internal.example.com/org/repo.git")
 	if auth == nil {
-		t.Fatal("CRAFT_TOKEN should be sent to any host")
+		t.Fatal("CRAFT_TOKEN should be sent to allowlisted host")
 	}
 	basic, ok := auth.(*http.BasicAuth)
 	if !ok {
@@ -72,9 +123,61 @@ func TestAuthCraftTokenSentToAnyHost(t *testing.T) {
 	}
 }
 
+func TestAuthCraftTokenBackwardCompatUnknownHostWarns(t *testing.T) {
+	resetWarningState(t)
+	t.Setenv("CRAFT_TOKEN", "craft-secret")
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("CRAFT_TOKEN_HOSTS", "")
+
+	var buf bytes.Buffer
+	oldWriter := warnWriter
+	warnWriter = &buf
+	t.Cleanup(func() { warnWriter = oldWriter })
+
+	auth := Auth("https://unknown-forge.example.com/org/repo.git")
+	if auth == nil {
+		t.Fatal("Backward compat: CRAFT_TOKEN should still be sent to unknown hosts without allowlist")
+	}
+	basic, ok := auth.(*http.BasicAuth)
+	if !ok {
+		t.Fatal("Expected *http.BasicAuth")
+	}
+	if basic.Password != "craft-secret" {
+		t.Errorf("Expected craft-secret, got %q", basic.Password)
+	}
+	if !strings.Contains(buf.String(), "warning") {
+		t.Error("Expected a warning about sending token to unknown host")
+	}
+	if !strings.Contains(buf.String(), "CRAFT_TOKEN_HOSTS") {
+		t.Error("Warning should mention CRAFT_TOKEN_HOSTS")
+	}
+}
+
+func TestAuthCraftTokenWarnsOnlyOnce(t *testing.T) {
+	resetWarningState(t)
+	t.Setenv("CRAFT_TOKEN", "craft-secret")
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("CRAFT_TOKEN_HOSTS", "")
+
+	var buf bytes.Buffer
+	oldWriter := warnWriter
+	warnWriter = &buf
+	t.Cleanup(func() { warnWriter = oldWriter })
+
+	Auth("https://unknown1.example.com/org/repo.git")
+	Auth("https://unknown2.example.com/org/repo.git")
+
+	warnings := strings.Count(buf.String(), "warning")
+	if warnings != 1 {
+		t.Errorf("Expected exactly 1 warning, got %d", warnings)
+	}
+}
+
 func TestAuthGitHubTokenSentToGitHub(t *testing.T) {
+	resetWarningState(t)
 	t.Setenv("CRAFT_TOKEN", "")
 	t.Setenv("GITHUB_TOKEN", "github-secret")
+	t.Setenv("CRAFT_TOKEN_HOSTS", "")
 
 	auth := Auth("https://github.com/org/repo.git")
 	if auth == nil {
@@ -97,7 +200,6 @@ func TestWrapAuthErrorPassthrough(t *testing.T) {
 
 func TestWrapAuthErrorAddsHint(t *testing.T) {
 	err := WrapAuthError(fmt.Errorf("timeout connecting"), "url")
-	// Timeout doesn't trigger auth hint
 	if err.Error() != "timeout connecting" {
 		t.Errorf("Non-auth errors should pass through, got %q", err.Error())
 	}

--- a/internal/fetch/gogit.go
+++ b/internal/fetch/gogit.go
@@ -16,6 +16,9 @@ import (
 
 const defaultGitTimeout = 2 * time.Minute
 
+// MaxFileSize is the maximum allowed size for a single file read from git (10 MB).
+const MaxFileSize = 10 << 20
+
 // GoGitFetcher implements GitFetcher using go-git with a local bare clone cache.
 type GoGitFetcher struct {
 	cache   *Cache
@@ -150,16 +153,22 @@ func (f *GoGitFetcher) ReadFiles(url, commitSHA string, paths []string) (map[str
 	for _, p := range paths {
 		file, err := tree.File(p)
 		if err != nil {
-			continue // silently skip missing files
+			if err == object.ErrFileNotFound || err == object.ErrDirectoryNotFound || err == object.ErrEntryNotFound {
+				continue // silently skip missing files
+			}
+			return nil, fmt.Errorf("looking up %s: %w", p, err)
 		}
 		reader, err := file.Reader()
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("opening %s: %w", p, err)
 		}
-		content, err := io.ReadAll(reader)
+		content, err := io.ReadAll(io.LimitReader(reader, int64(MaxFileSize)+1))
 		_ = reader.Close()
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("reading %s: %w", p, err)
+		}
+		if len(content) > MaxFileSize {
+			return nil, fmt.Errorf("file %s exceeds maximum size of %d bytes", p, MaxFileSize)
 		}
 		result[p] = content
 	}
@@ -182,6 +191,7 @@ func (f *GoGitFetcher) ensureRepo(url string) (*git.Repository, error) {
 	if err != nil {
 		// If locking fails, proceed without lock (best-effort)
 		// This handles systems where flock is unavailable
+		fmt.Fprintf(os.Stderr, "warning: could not acquire lock for %s: %v\n", repoPath, err)
 		lock = nil
 	}
 	defer func() {

--- a/internal/fetch/lock.go
+++ b/internal/fetch/lock.go
@@ -34,5 +34,6 @@ func (l *fileLock) Unlock() {
 	if l.file != nil {
 		_ = syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
 		_ = l.file.Close()
+		_ = os.Remove(l.path)
 	}
 }

--- a/internal/fetch/mock.go
+++ b/internal/fetch/mock.go
@@ -16,6 +16,11 @@ type MockFetcher struct {
 
 	// Files maps "url:commitSHA:path" to file content.
 	Files map[string][]byte
+
+	// Errors maps keys to errors for error injection in tests.
+	// Key formats: url for ListTags, "url:commitSHA" for ListTree,
+	// "url:commitSHA:path" for ReadFiles.
+	Errors map[string]error
 }
 
 // NewMockFetcher creates an empty MockFetcher.
@@ -25,6 +30,7 @@ func NewMockFetcher() *MockFetcher {
 		TagsByURL: make(map[string][]string),
 		Trees:     make(map[string][]string),
 		Files:     make(map[string][]byte),
+		Errors:    make(map[string]error),
 	}
 }
 
@@ -37,6 +43,9 @@ func (m *MockFetcher) ResolveRef(url, ref string) (string, error) {
 }
 
 func (m *MockFetcher) ListTags(url string) ([]string, error) {
+	if err, ok := m.Errors[url]; ok {
+		return nil, err
+	}
 	if tags, ok := m.TagsByURL[url]; ok {
 		return tags, nil
 	}
@@ -45,6 +54,9 @@ func (m *MockFetcher) ListTags(url string) ([]string, error) {
 
 func (m *MockFetcher) ListTree(url, commitSHA string) ([]string, error) {
 	key := url + ":" + commitSHA
+	if err, ok := m.Errors[key]; ok {
+		return nil, err
+	}
 	if tree, ok := m.Trees[key]; ok {
 		return tree, nil
 	}
@@ -55,6 +67,9 @@ func (m *MockFetcher) ReadFiles(url, commitSHA string, paths []string) (map[stri
 	result := make(map[string][]byte)
 	for _, p := range paths {
 		key := url + ":" + commitSHA + ":" + p
+		if err, ok := m.Errors[key]; ok {
+			return nil, err
+		}
 		if content, ok := m.Files[key]; ok {
 			result[p] = content
 		}

--- a/internal/pinfile/types.go
+++ b/internal/pinfile/types.go
@@ -26,4 +26,7 @@ type ResolvedEntry struct {
 
 	// Skills lists the skill names discovered in the dependency.
 	Skills []string `yaml:"skills"`
+
+	// SkillPaths lists the skill directory paths relative to the repo root.
+	SkillPaths []string `yaml:"skill_paths,omitempty"`
 }

--- a/internal/pinfile/write.go
+++ b/internal/pinfile/write.go
@@ -52,6 +52,19 @@ func Write(p *Pinfile, w io.Writer) error {
 			}
 			entryMap.Content = append(entryMap.Content, skillsKey, skillsSeq)
 
+			// skill_paths as sequence (only if non-empty)
+			if len(entry.SkillPaths) > 0 {
+				spKey := &yaml.Node{Kind: yaml.ScalarNode, Value: "skill_paths"}
+				spSeq := &yaml.Node{Kind: yaml.SequenceNode}
+				for _, sp := range entry.SkillPaths {
+					spSeq.Content = append(spSeq.Content, &yaml.Node{
+						Kind:  yaml.ScalarNode,
+						Value: sp,
+					})
+				}
+				entryMap.Content = append(entryMap.Content, spKey, spSeq)
+			}
+
 			resolvedMap.Content = append(resolvedMap.Content, urlNode, entryMap)
 		}
 

--- a/internal/pinfile/write_test.go
+++ b/internal/pinfile/write_test.go
@@ -12,9 +12,10 @@ func TestWriteRoundTrip(t *testing.T) {
 		PinVersion: 1,
 		Resolved: map[string]ResolvedEntry{
 			"github.com/example/git-skills@v1.0.0": {
-				Commit:    "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
-				Integrity: "sha256-Xk9jR2mN5pQ8vW3yB7cF1dA4hL6tS0uE9iO2wR5nM3s=",
-				Skills:    []string{"git-commit", "git-branch"},
+				Commit:     "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+				Integrity:  "sha256-Xk9jR2mN5pQ8vW3yB7cF1dA4hL6tS0uE9iO2wR5nM3s=",
+				Skills:     []string{"git-commit", "git-branch"},
+				SkillPaths: []string{"skills/git-commit", "skills/git-branch"},
 			},
 			"github.com/other-org/style-skills@v2.3.1": {
 				Commit:    "f6e5d4c3b2a1f6e5d4c3b2a1f6e5d4c3b2a1f6e5",
@@ -56,6 +57,15 @@ func TestWriteRoundTrip(t *testing.T) {
 		}
 		if len(got.Skills) != len(want.Skills) {
 			t.Errorf("Resolved[%q].Skills count = %d, want %d", url, len(got.Skills), len(want.Skills))
+		}
+		if len(got.SkillPaths) != len(want.SkillPaths) {
+			t.Errorf("Resolved[%q].SkillPaths count = %d, want %d", url, len(got.SkillPaths), len(want.SkillPaths))
+		} else {
+			for i, sp := range want.SkillPaths {
+				if got.SkillPaths[i] != sp {
+					t.Errorf("Resolved[%q].SkillPaths[%d] = %q, want %q", url, i, got.SkillPaths[i], sp)
+				}
+			}
 		}
 	}
 }

--- a/internal/resolve/graph.go
+++ b/internal/resolve/graph.go
@@ -1,6 +1,9 @@
 package resolve
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+)
 
 // Graph is a directed dependency graph used for cycle detection
 // and topological ordering.
@@ -40,7 +43,13 @@ func (g *Graph) DetectCycles() []string {
 	color := make(map[string]int)
 	parent := make(map[string]string)
 
+	ids := make([]string, 0, len(g.nodes))
 	for id := range g.nodes {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	for _, id := range ids {
 		color[id] = white
 	}
 
@@ -75,7 +84,7 @@ func (g *Graph) DetectCycles() []string {
 		return nil
 	}
 
-	for id := range g.nodes {
+	for _, id := range ids {
 		if color[id] == white {
 			if cycle := dfs(id); cycle != nil {
 				return cycle

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -188,10 +188,11 @@ func (r *Resolver) Resolve(m *manifest.Manifest, opts ResolveOptions) (*ResolveR
 	}
 	for _, dep := range resolved {
 		pf.Resolved[dep.URL] = pinfile.ResolvedEntry{
-			Commit:    dep.Commit,
-			Integrity: dep.Integrity,
-			Source:    dep.Source,
-			Skills:    dep.Skills,
+			Commit:     dep.Commit,
+			Integrity:  dep.Integrity,
+			Source:     dep.Source,
+			Skills:     dep.Skills,
+			SkillPaths: dep.SkillPaths,
 		}
 	}
 
@@ -269,6 +270,7 @@ func (r *Resolver) resolveOne(dep ResolvedDep, opts ResolveOptions) (ResolvedDep
 			dep.Commit = entry.Commit
 			dep.Integrity = entry.Integrity
 			dep.Skills = entry.Skills
+			dep.SkillPaths = entry.SkillPaths
 			return dep, nil
 		}
 	}

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -15,6 +15,11 @@ import (
 	"github.com/erdemtuna/craft/internal/skill"
 )
 
+const (
+	maxResolutionDepth = 20
+	maxTotalDeps       = 200
+)
+
 // Resolver orchestrates dependency resolution using MVS.
 type Resolver struct {
 	fetcher fetch.GitFetcher
@@ -57,7 +62,7 @@ func (r *Resolver) Resolve(m *manifest.Manifest, opts ResolveOptions) (*ResolveR
 	rootID := m.Name
 
 	visited := make(map[string]string) // identity → version first visited
-	allDeps, err := r.collectDeps(m, rootID, "", graph, opts, visited)
+	allDeps, err := r.collectDeps(m, rootID, "", graph, opts, visited, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +145,7 @@ func (r *Resolver) Resolve(m *manifest.Manifest, opts ResolveOptions) (*ResolveR
 			}
 
 			if len(depManifest.Dependencies) > 0 {
-				transitive, err := r.collectDeps(depManifest, identity, dep.URL, graph, opts, visited)
+				transitive, err := r.collectDeps(depManifest, identity, dep.URL, graph, opts, visited, 0)
 				if err != nil {
 					return nil, err
 				}
@@ -200,7 +205,11 @@ func (r *Resolver) Resolve(m *manifest.Manifest, opts ResolveOptions) (*ResolveR
 }
 
 // collectDeps recursively collects all dependency requirements.
-func (r *Resolver) collectDeps(m *manifest.Manifest, parentID, source string, graph *Graph, opts ResolveOptions, visited map[string]string) ([]ResolvedDep, error) {
+func (r *Resolver) collectDeps(m *manifest.Manifest, parentID, source string, graph *Graph, opts ResolveOptions, visited map[string]string, depth int) ([]ResolvedDep, error) {
+	if depth > maxResolutionDepth {
+		return nil, fmt.Errorf("dependency resolution exceeded maximum depth of %d (possible deep dependency chain)", maxResolutionDepth)
+	}
+
 	var allDeps []ResolvedDep
 
 	for alias, depURL := range m.Dependencies {
@@ -224,6 +233,9 @@ func (r *Resolver) collectDeps(m *manifest.Manifest, parentID, source string, gr
 			continue
 		}
 		visited[identity] = parsed.Version
+		if len(visited) > maxTotalDeps {
+			return nil, fmt.Errorf("dependency resolution exceeded maximum of %d total dependencies", maxTotalDeps)
+		}
 
 		cloneURL := fetch.NormalizeCloneURL(identity)
 
@@ -245,7 +257,7 @@ func (r *Resolver) collectDeps(m *manifest.Manifest, parentID, source string, gr
 			}
 
 			if len(depManifest.Dependencies) > 0 {
-				transitive, err := r.collectDeps(depManifest, identity, depURL, graph, opts, visited)
+				transitive, err := r.collectDeps(depManifest, identity, depURL, graph, opts, visited, depth+1)
 				if err != nil {
 					return nil, err
 				}
@@ -327,6 +339,12 @@ func (r *Resolver) discoverFromManifestSkills(cloneURL, commitSHA string, skillD
 		return nil, nil, nil, err
 	}
 
+	// Fetch tree once for all skill directories
+	treePaths, listErr := r.fetcher.ListTree(cloneURL, commitSHA)
+	if listErr != nil {
+		return nil, nil, nil, fmt.Errorf("listing tree for integrity: %w", listErr)
+	}
+
 	var names []string
 	var dirs []string
 	allFiles := make(map[string][]byte)
@@ -344,22 +362,14 @@ func (r *Resolver) discoverFromManifestSkills(cloneURL, commitSHA string, skillD
 			continue
 		}
 
+		if manifest.ValidateName(fm.Name) != nil {
+			continue
+		}
+
 		names = append(names, fm.Name)
 		dirs = append(dirs, sp)
 
-		// Read all files in skill directory for integrity
-		treePaths, listErr := r.fetcher.ListTree(cloneURL, commitSHA)
-		if listErr != nil {
-			return nil, nil, nil, fmt.Errorf("listing tree for integrity: %w", listErr)
-		}
-		prefix := sp + "/"
-		var dirPaths []string
-		for _, p := range treePaths {
-			if strings.HasPrefix(p, prefix) {
-				dirPaths = append(dirPaths, p)
-			}
-		}
-		dirFiles, readErr := r.fetcher.ReadFiles(cloneURL, commitSHA, dirPaths)
+		dirFiles, readErr := CollectSkillDirFiles(r.fetcher, cloneURL, commitSHA, treePaths, sp)
 		if readErr != nil {
 			return nil, nil, nil, fmt.Errorf("reading skill files for integrity: %w", readErr)
 		}
@@ -409,6 +419,10 @@ func (r *Resolver) autoDiscoverSkills(cloneURL, commitSHA string) ([]string, []s
 			continue
 		}
 
+		if manifest.ValidateName(fm.Name) != nil {
+			continue
+		}
+
 		skillDir := strings.TrimSuffix(mdPath, "/SKILL.md")
 		if skillDir == "SKILL.md" {
 			skillDir = ""
@@ -417,22 +431,7 @@ func (r *Resolver) autoDiscoverSkills(cloneURL, commitSHA string) ([]string, []s
 		names = append(names, fm.Name)
 		dirs = append(dirs, skillDir)
 
-		// Collect files in skill directory
-		prefix := skillDir + "/"
-		if skillDir == "" {
-			prefix = ""
-		}
-		var dirPaths []string
-		for _, p := range allPaths {
-			if prefix == "" || strings.HasPrefix(p, prefix) {
-				// For root-level skills, exclude infrastructure files
-				if prefix == "" && IsInfraFile(p) {
-					continue
-				}
-				dirPaths = append(dirPaths, p)
-			}
-		}
-		dirFiles, readErr := r.fetcher.ReadFiles(cloneURL, commitSHA, dirPaths)
+		dirFiles, readErr := CollectSkillDirFiles(r.fetcher, cloneURL, commitSHA, allPaths, skillDir)
 		if readErr != nil {
 			return nil, nil, nil, fmt.Errorf("reading skill files for integrity: %w", readErr)
 		}
@@ -470,6 +469,29 @@ func detectCollisions(resolved []ResolvedDep) error {
 		}
 	}
 	return nil
+}
+
+// CollectSkillDirFiles filters allPaths by skillDir, excludes infra files for
+// root-level skills, and reads the matching files via fetcher. Returned paths
+// are original (not stripped). Callers that need relative paths should strip
+// the prefix themselves.
+func CollectSkillDirFiles(fetcher fetch.GitFetcher, cloneURL, commitSHA string, allPaths []string, skillDir string) (map[string][]byte, error) {
+	prefix := skillDir + "/"
+	if skillDir == "" {
+		prefix = ""
+	}
+
+	var filePaths []string
+	for _, p := range allPaths {
+		if prefix == "" || strings.HasPrefix(p, prefix) {
+			if prefix == "" && IsInfraFile(p) {
+				continue
+			}
+			filePaths = append(filePaths, p)
+		}
+	}
+
+	return fetcher.ReadFiles(cloneURL, commitSHA, filePaths)
 }
 
 // IsInfraFile returns true for common infrastructure files that should not

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -316,7 +316,10 @@ func (r *Resolver) discoverSkillsForDep(cloneURL, commitSHA string) (names []str
 	if readErr == nil {
 		if craftYAML, ok := craftFiles["craft.yaml"]; ok {
 			depManifest, parseErr := manifest.Parse(bytes.NewReader(craftYAML))
-			if parseErr == nil && len(depManifest.Skills) > 0 {
+			if parseErr != nil {
+				return nil, nil, nil, fmt.Errorf("parsing craft.yaml in %s: %w", cloneURL, parseErr)
+			}
+			if len(depManifest.Skills) > 0 {
 				return r.discoverFromManifestSkills(cloneURL, commitSHA, depManifest.Skills)
 			}
 		}
@@ -497,20 +500,21 @@ func CollectSkillDirFiles(fetcher fetch.GitFetcher, cloneURL, commitSHA string, 
 // IsInfraFile returns true for common infrastructure files that should not
 // be included in root-level skill file collection. Subdirectory skills
 // are not affected — this only applies when SKILL.md is at the repo root.
+var infraFiles = map[string]bool{
+	"license": true, "licence": true,
+	"license.md": true, "licence.md": true,
+	"license.txt": true, "licence.txt": true,
+	"readme.md": true, "readme.txt": true, "readme": true,
+	"changelog.md": true, "changelog.txt": true, "changelog": true,
+	"contributing.md": true, "contributing.txt": true,
+	"code_of_conduct.md": true,
+	"craft.yaml": true,
+	".gitignore": true, ".gitattributes": true,
+}
+
 func IsInfraFile(path string) bool {
 	// Exclude common infrastructure files at any level
 	base := strings.ToLower(filepath.Base(path))
-	infraFiles := map[string]bool{
-		"license": true, "licence": true,
-		"license.md": true, "licence.md": true,
-		"license.txt": true, "licence.txt": true,
-		"readme.md": true, "readme.txt": true, "readme": true,
-		"changelog.md": true, "changelog.txt": true, "changelog": true,
-		"contributing.md": true, "contributing.txt": true,
-		"code_of_conduct.md": true,
-		"craft.yaml": true,
-		".gitignore": true, ".gitattributes": true,
-	}
 	if infraFiles[base] {
 		return true
 	}

--- a/internal/resolve/resolver_test.go
+++ b/internal/resolve/resolver_test.go
@@ -1,6 +1,7 @@
 package resolve
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -271,6 +272,42 @@ func TestCompareSemver(t *testing.T) {
 				t.Errorf("semver.Compare(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestResolveDepthLimit(t *testing.T) {
+	mock := newTestFetcher()
+
+	// Build a chain of maxResolutionDepth+2 packages: dep0 → dep1 → ... → depN
+	// Each dep depends on the next, exceeding the depth limit.
+	chainLen := maxResolutionDepth + 2
+	for i := 0; i < chainLen; i++ {
+		identity := fmt.Sprintf("github.com/org/dep%d", i)
+		cloneURL := "https://" + identity + ".git"
+		commitSHA := fmt.Sprintf("sha%d", i)
+		mock.Refs[cloneURL+":v1.0.0"] = commitSHA
+		mock.Trees[cloneURL+":"+commitSHA] = []string{"skills/s/SKILL.md"}
+		mock.Files[cloneURL+":"+commitSHA+":skills/s/SKILL.md"] = []byte(fmt.Sprintf("---\nname: skill-%d\n---\n", i))
+
+		if i < chainLen-1 {
+			nextIdentity := fmt.Sprintf("github.com/org/dep%d", i+1)
+			mock.Files[cloneURL+":"+commitSHA+":craft.yaml"] = []byte(fmt.Sprintf(
+				"schema_version: 1\nname: dep%d\nversion: 1.0.0\nskills:\n  - ./skills/s\ndependencies:\n  next: %s@v1.0.0\n", i, nextIdentity))
+		}
+	}
+
+	resolver := NewResolver(mock)
+	m := &manifest.Manifest{
+		Name:         "root",
+		Dependencies: map[string]string{"dep0": "github.com/org/dep0@v1.0.0"},
+	}
+
+	_, err := resolver.Resolve(m, ResolveOptions{})
+	if err == nil {
+		t.Fatal("Expected depth limit error")
+	}
+	if !strings.Contains(err.Error(), "exceeded maximum depth") {
+		t.Errorf("Error should mention depth limit, got: %v", err)
 	}
 }
 

--- a/internal/resolve/resolver_test.go
+++ b/internal/resolve/resolver_test.go
@@ -187,9 +187,10 @@ func TestResolvePinfileReuse(t *testing.T) {
 		PinVersion: 1,
 		Resolved: map[string]pinfile.ResolvedEntry{
 			"github.com/org/skills@v1.0.0": {
-				Commit:    "pinned-commit",
-				Integrity: "sha256-pinned=",
-				Skills:    []string{"my-skill"},
+				Commit:     "pinned-commit",
+				Integrity:  "sha256-pinned=",
+				Skills:     []string{"my-skill"},
+				SkillPaths: []string{"skills/my-skill"},
 			},
 		},
 	}
@@ -208,6 +209,10 @@ func TestResolvePinfileReuse(t *testing.T) {
 	// Should reuse pinned commit, not re-resolve
 	if result.Resolved[0].Commit != "pinned-commit" {
 		t.Errorf("Should reuse pinned commit, got %q", result.Resolved[0].Commit)
+	}
+	// Should preserve SkillPaths from pinfile
+	if len(result.Resolved[0].SkillPaths) != 1 || result.Resolved[0].SkillPaths[0] != "skills/my-skill" {
+		t.Errorf("Should preserve SkillPaths from pinfile, got %v", result.Resolved[0].SkillPaths)
 	}
 }
 

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -45,7 +45,7 @@ func (p *Progress) Start(msg string) {
 	if !p.isTTY {
 		return
 	}
-	fmt.Fprintf(p.w, "\r\033[K%s", msg)
+	_, _ = fmt.Fprintf(p.w, "\r\033[K%s", msg)
 }
 
 // Update prints a progress update, overwriting the previous line on TTY.
@@ -55,7 +55,7 @@ func (p *Progress) Update(msg string) {
 	if !p.isTTY {
 		return
 	}
-	fmt.Fprintf(p.w, "\r\033[K%s", msg)
+	_, _ = fmt.Fprintf(p.w, "\r\033[K%s", msg)
 }
 
 // UpdateCount prints a counted progress line like "Fetching dependency 2/5...".
@@ -70,7 +70,7 @@ func (p *Progress) Done(msg string) {
 	if !p.isTTY {
 		return
 	}
-	fmt.Fprintf(p.w, "\r\033[K%s\n", msg)
+	_, _ = fmt.Fprintf(p.w, "\r\033[K%s\n", msg)
 }
 
 // Fail clears the progress line and prints an error message.
@@ -80,7 +80,7 @@ func (p *Progress) Fail(msg string) {
 	if !p.isTTY {
 		return
 	}
-	fmt.Fprintf(p.w, "\r\033[K%s\n", msg)
+	_, _ = fmt.Fprintf(p.w, "\r\033[K%s\n", msg)
 }
 
 // IsTTY returns whether progress output is enabled.

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -1,0 +1,89 @@
+// Package ui provides TTY-aware progress output and dependency tree rendering.
+package ui
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"golang.org/x/term"
+)
+
+// Progress provides TTY-aware status output to stderr.
+// On TTY: writes status lines with \r carriage return (overwriting previous).
+// On non-TTY: suppresses progress output entirely (CI-friendly).
+type Progress struct {
+	w     io.Writer
+	isTTY bool
+	mu    sync.Mutex
+}
+
+// NewProgress creates a Progress that writes to stderr.
+// Progress is suppressed when stderr is not a TTY.
+func NewProgress() *Progress {
+	isTTY := term.IsTerminal(int(os.Stderr.Fd()))
+	return &Progress{
+		w:     os.Stderr,
+		isTTY: isTTY,
+	}
+}
+
+// NewProgressWriter creates a Progress that writes to the given writer.
+// isTTY controls whether progress output is emitted.
+func NewProgressWriter(w io.Writer, isTTY bool) *Progress {
+	return &Progress{
+		w:     w,
+		isTTY: isTTY,
+	}
+}
+
+// Start prints an initial status message.
+func (p *Progress) Start(msg string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.isTTY {
+		return
+	}
+	fmt.Fprintf(p.w, "\r\033[K%s", msg)
+}
+
+// Update prints a progress update, overwriting the previous line on TTY.
+func (p *Progress) Update(msg string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.isTTY {
+		return
+	}
+	fmt.Fprintf(p.w, "\r\033[K%s", msg)
+}
+
+// UpdateCount prints a counted progress line like "Fetching dependency 2/5...".
+func (p *Progress) UpdateCount(action string, current, total int) {
+	p.Update(fmt.Sprintf("%s %d/%d...", action, current, total))
+}
+
+// Done clears the progress line and prints a completion message.
+func (p *Progress) Done(msg string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.isTTY {
+		return
+	}
+	fmt.Fprintf(p.w, "\r\033[K%s\n", msg)
+}
+
+// Fail clears the progress line and prints an error message.
+func (p *Progress) Fail(msg string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.isTTY {
+		return
+	}
+	fmt.Fprintf(p.w, "\r\033[K%s\n", msg)
+}
+
+// IsTTY returns whether progress output is enabled.
+func (p *Progress) IsTTY() bool {
+	return p.isTTY
+}

--- a/internal/ui/progress_test.go
+++ b/internal/ui/progress_test.go
@@ -1,0 +1,70 @@
+package ui
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestProgressTTYMode(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewProgressWriter(&buf, true)
+
+	p.Start("Resolving dependencies...")
+	if buf.Len() == 0 {
+		t.Error("expected output in TTY mode, got none")
+	}
+	if got := buf.String(); got != "\r\033[KResolving dependencies..." {
+		t.Errorf("unexpected Start output: %q", got)
+	}
+
+	buf.Reset()
+	p.Update("Fetching github.com/org/repo...")
+	if got := buf.String(); got != "\r\033[KFetching github.com/org/repo..." {
+		t.Errorf("unexpected Update output: %q", got)
+	}
+
+	buf.Reset()
+	p.UpdateCount("Fetching dependency", 2, 5)
+	if got := buf.String(); got != "\r\033[KFetching dependency 2/5..." {
+		t.Errorf("unexpected UpdateCount output: %q", got)
+	}
+
+	buf.Reset()
+	p.Done("Installed 8 skills from 3 packages")
+	if got := buf.String(); got != "\r\033[KInstalled 8 skills from 3 packages\n" {
+		t.Errorf("unexpected Done output: %q", got)
+	}
+
+	buf.Reset()
+	p.Fail("Resolution failed")
+	if got := buf.String(); got != "\r\033[KResolution failed\n" {
+		t.Errorf("unexpected Fail output: %q", got)
+	}
+}
+
+func TestProgressNonTTYMode(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewProgressWriter(&buf, false)
+
+	p.Start("Resolving...")
+	p.Update("Fetching...")
+	p.UpdateCount("Fetching dependency", 1, 3)
+	p.Done("Done")
+	p.Fail("Error")
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no output in non-TTY mode, got: %q", buf.String())
+	}
+}
+
+func TestProgressIsTTY(t *testing.T) {
+	tty := NewProgressWriter(nil, true)
+	if !tty.IsTTY() {
+		t.Error("expected IsTTY() = true")
+	}
+
+	nonTTY := NewProgressWriter(nil, false)
+	if nonTTY.IsTTY() {
+		t.Error("expected IsTTY() = false")
+	}
+}

--- a/internal/ui/tree.go
+++ b/internal/ui/tree.go
@@ -17,7 +17,7 @@ type DepNode struct {
 // RenderTree writes a box-drawing dependency tree to w.
 // localSkills are shown first under "Local skills:", then remote dependencies.
 func RenderTree(w io.Writer, packageName string, localSkills []string, deps []DepNode) {
-	fmt.Fprintf(w, "%s\n", packageName)
+	_, _ = fmt.Fprintf(w, "%s\n", packageName)
 
 	hasLocal := len(localSkills) > 0
 	hasDeps := len(deps) > 0
@@ -29,13 +29,13 @@ func RenderTree(w io.Writer, packageName string, localSkills []string, deps []De
 			connector = "└── "
 			childPrefix = "    "
 		}
-		fmt.Fprintf(w, "%sLocal skills\n", connector)
+		_, _ = fmt.Fprintf(w, "%sLocal skills\n", connector)
 		for i, skill := range localSkills {
 			skillConn := "├── "
 			if i == len(localSkills)-1 {
 				skillConn = "└── "
 			}
-			fmt.Fprintf(w, "%s%s%s\n", childPrefix, skillConn, skill)
+			_, _ = fmt.Fprintf(w, "%s%s%s\n", childPrefix, skillConn, skill)
 		}
 	}
 
@@ -55,14 +55,14 @@ func RenderTree(w io.Writer, packageName string, localSkills []string, deps []De
 			childPrefix = "    "
 		}
 
-		fmt.Fprintf(w, "%s%s (%s)\n", connector, dep.Alias, dep.URL)
+		_, _ = fmt.Fprintf(w, "%s%s (%s)\n", connector, dep.Alias, dep.URL)
 
 		for j, skill := range dep.Skills {
 			skillConn := "├── "
 			if j == len(dep.Skills)-1 {
 				skillConn = "└── "
 			}
-			fmt.Fprintf(w, "%s%s%s\n", childPrefix, skillConn, skill)
+			_, _ = fmt.Fprintf(w, "%s%s%s\n", childPrefix, skillConn, skill)
 		}
 	}
 }

--- a/internal/ui/tree.go
+++ b/internal/ui/tree.go
@@ -1,0 +1,75 @@
+package ui
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// DepNode represents a resolved dependency for tree display.
+type DepNode struct {
+	Alias  string
+	URL    string
+	Skills []string
+}
+
+// RenderTree writes a box-drawing dependency tree to w.
+// localSkills are shown first under "Local skills:", then remote dependencies.
+func RenderTree(w io.Writer, packageName string, localSkills []string, deps []DepNode) {
+	fmt.Fprintf(w, "%s\n", packageName)
+
+	hasLocal := len(localSkills) > 0
+	hasDeps := len(deps) > 0
+
+	if hasLocal {
+		connector := "├── "
+		childPrefix := "│   "
+		if !hasDeps {
+			connector = "└── "
+			childPrefix = "    "
+		}
+		fmt.Fprintf(w, "%sLocal skills\n", connector)
+		for i, skill := range localSkills {
+			skillConn := "├── "
+			if i == len(localSkills)-1 {
+				skillConn = "└── "
+			}
+			fmt.Fprintf(w, "%s%s%s\n", childPrefix, skillConn, skill)
+		}
+	}
+
+	// Sort deps by alias for deterministic output
+	sorted := make([]DepNode, len(deps))
+	copy(sorted, deps)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Alias < sorted[j].Alias
+	})
+
+	for i, dep := range sorted {
+		isLast := i == len(sorted)-1
+		connector := "├── "
+		childPrefix := "│   "
+		if isLast {
+			connector = "└── "
+			childPrefix = "    "
+		}
+
+		fmt.Fprintf(w, "%s%s (%s)\n", connector, dep.Alias, dep.URL)
+
+		for j, skill := range dep.Skills {
+			skillConn := "├── "
+			if j == len(dep.Skills)-1 {
+				skillConn = "└── "
+			}
+			fmt.Fprintf(w, "%s%s%s\n", childPrefix, skillConn, skill)
+		}
+	}
+}
+
+// FormatTree renders the tree to a string for convenience.
+func FormatTree(packageName string, localSkills []string, deps []DepNode) string {
+	var sb strings.Builder
+	RenderTree(&sb, packageName, localSkills, deps)
+	return sb.String()
+}

--- a/internal/ui/tree_test.go
+++ b/internal/ui/tree_test.go
@@ -1,0 +1,99 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderTreeFull(t *testing.T) {
+	deps := []DepNode{
+		{
+			Alias:  "git-operations",
+			URL:    "github.com/example/git-skills@v1.0.0",
+			Skills: []string{"git-commit", "git-branch", "git-operations"},
+		},
+		{
+			Alias:  "style-guides",
+			URL:    "github.com/other-org/style-skills@v2.3.1",
+			Skills: []string{"python-style", "js-style"},
+		},
+	}
+
+	localSkills := []string{"lint-check", "review-pr"}
+
+	got := FormatTree("code-quality@1.0.0", localSkills, deps)
+
+	expected := `code-quality@1.0.0
+├── Local skills
+│   ├── lint-check
+│   └── review-pr
+├── git-operations (github.com/example/git-skills@v1.0.0)
+│   ├── git-commit
+│   ├── git-branch
+│   └── git-operations
+└── style-guides (github.com/other-org/style-skills@v2.3.1)
+    ├── python-style
+    └── js-style
+`
+
+	if got != expected {
+		t.Errorf("tree mismatch:\nGOT:\n%s\nEXPECTED:\n%s", got, expected)
+	}
+}
+
+func TestRenderTreeNoLocalSkills(t *testing.T) {
+	deps := []DepNode{
+		{
+			Alias:  "tools",
+			URL:    "github.com/org/tools@v1.0.0",
+			Skills: []string{"formatter"},
+		},
+	}
+
+	got := FormatTree("my-package@0.1.0", nil, deps)
+
+	expected := `my-package@0.1.0
+└── tools (github.com/org/tools@v1.0.0)
+    └── formatter
+`
+
+	if got != expected {
+		t.Errorf("tree mismatch:\nGOT:\n%s\nEXPECTED:\n%s", got, expected)
+	}
+}
+
+func TestRenderTreeLocalSkillsOnly(t *testing.T) {
+	got := FormatTree("local-only@1.0.0", []string{"my-skill"}, nil)
+
+	expected := `local-only@1.0.0
+└── Local skills
+    └── my-skill
+`
+
+	if got != expected {
+		t.Errorf("tree mismatch:\nGOT:\n%s\nEXPECTED:\n%s", got, expected)
+	}
+}
+
+func TestRenderTreeEmpty(t *testing.T) {
+	got := FormatTree("empty@0.0.0", nil, nil)
+
+	if !strings.HasPrefix(got, "empty@0.0.0\n") {
+		t.Errorf("expected package name header, got: %q", got)
+	}
+}
+
+func TestRenderTreeDeterministicOrder(t *testing.T) {
+	deps := []DepNode{
+		{Alias: "zebra", URL: "github.com/z/z@v1.0.0", Skills: []string{"z-skill"}},
+		{Alias: "alpha", URL: "github.com/a/a@v1.0.0", Skills: []string{"a-skill"}},
+	}
+
+	got := FormatTree("pkg@1.0.0", nil, deps)
+
+	alphaIdx := strings.Index(got, "alpha")
+	zebraIdx := strings.Index(got, "zebra")
+	if alphaIdx > zebraIdx {
+		t.Error("expected alphabetical ordering: alpha before zebra")
+	}
+}


### PR DESCRIPTION
## Summary

Workflow 3 of 3 for craft (Agent Skills Package Manager). Completes the MVP with the remaining two CLI commands, npm-style UI, multi-agent detection improvements, and documentation.

## Changes

### New Commands
- **`craft add [alias] <url>`** — Add a dependency to `craft.yaml` with verification. Derives alias from repo name if not provided. `--install` flag triggers full install pipeline after add.
- **`craft remove <alias>`** — Remove a dependency, update `craft.pin.yaml`, and clean up orphaned skills. Shared skills retained when provided by multiple deps.

### UI Package (`internal/ui/`)
- **Progress indicators** — TTY-aware status output with `\r` carriage return. Suppressed on non-TTY (CI-friendly).
- **Dependency tree visualization** — Box-drawing tree on stderr after install/update. Shows local skills at top, remote deps sorted alphabetically.

### Multi-Agent Detection
- `DetectAll()` returns all detected agents (non-erroring).
- Interactive prompt (Claude Code / Copilot / Both) when multiple agents detected on TTY stdin.
- Non-TTY fallback to error with `--target` hint.
- "Both" option installs to each agent path.

### Error Messages
- All commands use `hint:` keyword (migrated from `fix:` in validate.go).
- Missing `craft.yaml` → "run `craft init`" hint.
- Improved hints for network errors, missing aliases, invalid URLs.

### Security
- Path traversal protection in `craft remove` (matches `install.go`'s existing guard).

### Documentation
- README expanded: 3 new commands documented, Agent Support section, Known Limitations section.

## Stats
- **1,756 lines added**, 55 removed across 22 files
- New package: `internal/ui/` (4 files)
- New commands: `internal/cli/add.go`, `internal/cli/remove.go` (with full test suites)
- All 15 packages pass `go test`, `go vet`, `go build`

## Review Notes
- SoT final review caught and fixed: broken "Both" multi-agent install path, path traversal vulnerability in `craft remove`, dead code removal.
