### PR TITLE
Fix some bugs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thank you for your interest in contributing to craft! This guide covers everythi
 
 | Tool | Install |
 |------|---------|
-| [Go 1.24+](https://go.dev/dl/) | Required |
+| [Go 1.26+](https://go.dev/dl/) | Required |
 | [Task](https://taskfile.dev/) | `go install github.com/go-task/task/v3/cmd/task@latest` |
 | [golangci-lint](https://golangci-lint.run/welcome/install/) | `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest` |
 | [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) | `go install golang.org/x/vuln/cmd/govulncheck@latest` |

--- a/internal/fetch/auth.go
+++ b/internal/fetch/auth.go
@@ -92,14 +92,14 @@ func isTrustedHost(rawURL string) bool {
 // should attempt the operation and wrap any auth errors with suggestions.
 func Auth(url string) transport.AuthMethod {
 	// CRAFT_TOKEN: scoped to trusted hosts
-	if token := os.Getenv("CRAFT_TOKEN"); token != "" && isTrustedHost(url) {
+	if token := strings.TrimSpace(os.Getenv("CRAFT_TOKEN")); token != "" && isTrustedHost(url) {
 		return &http.BasicAuth{
 			Username: "x-access-token",
 			Password: token,
 		}
 	}
 	// GITHUB_TOKEN: scoped to GitHub hosts only
-	if token := os.Getenv("GITHUB_TOKEN"); token != "" && isGitHubHost(url) {
+	if token := strings.TrimSpace(os.Getenv("GITHUB_TOKEN")); token != "" && isGitHubHost(url) {
 		return &http.BasicAuth{
 			Username: "x-access-token",
 			Password: token,

--- a/internal/fetch/auth_test.go
+++ b/internal/fetch/auth_test.go
@@ -192,6 +192,56 @@ func TestAuthGitHubTokenSentToGitHub(t *testing.T) {
 	}
 }
 
+func TestAuthCraftTokenWhitespaceTrimmed(t *testing.T) {
+	resetWarningState(t)
+	t.Setenv("CRAFT_TOKEN", "  craft-secret\n")
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("CRAFT_TOKEN_HOSTS", "")
+
+	auth := Auth("https://github.com/org/repo.git")
+	if auth == nil {
+		t.Fatal("Expected auth even with whitespace-padded CRAFT_TOKEN")
+	}
+	basic, ok := auth.(*http.BasicAuth)
+	if !ok {
+		t.Fatal("Expected *http.BasicAuth")
+	}
+	if basic.Password != "craft-secret" {
+		t.Errorf("Expected trimmed token %q, got %q", "craft-secret", basic.Password)
+	}
+}
+
+func TestAuthGitHubTokenWhitespaceTrimmed(t *testing.T) {
+	resetWarningState(t)
+	t.Setenv("CRAFT_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "\tgithub-secret  ")
+	t.Setenv("CRAFT_TOKEN_HOSTS", "")
+
+	auth := Auth("https://github.com/org/repo.git")
+	if auth == nil {
+		t.Fatal("Expected auth even with whitespace-padded GITHUB_TOKEN")
+	}
+	basic, ok := auth.(*http.BasicAuth)
+	if !ok {
+		t.Fatal("Expected *http.BasicAuth")
+	}
+	if basic.Password != "github-secret" {
+		t.Errorf("Expected trimmed token %q, got %q", "github-secret", basic.Password)
+	}
+}
+
+func TestAuthWhitespaceOnlyTokenIgnored(t *testing.T) {
+	resetWarningState(t)
+	t.Setenv("CRAFT_TOKEN", "   \n\t")
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("CRAFT_TOKEN_HOSTS", "")
+
+	auth := Auth("https://github.com/org/repo.git")
+	if auth != nil {
+		t.Error("Expected nil auth for whitespace-only token")
+	}
+}
+
 func TestWrapAuthErrorPassthrough(t *testing.T) {
 	if err := WrapAuthError(nil, "url"); err != nil {
 		t.Error("Expected nil for nil error")

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -53,7 +53,8 @@ type ResolveResult struct {
 func (r *Resolver) Resolve(m *manifest.Manifest, opts ResolveOptions) (*ResolveResult, error) {
 	if len(m.Dependencies) == 0 {
 		return &ResolveResult{
-			Pinfile: &pinfile.Pinfile{PinVersion: 1, Resolved: map[string]pinfile.ResolvedEntry{}},
+			Resolved: []ResolvedDep{},
+			Pinfile:  &pinfile.Pinfile{PinVersion: 1, Resolved: map[string]pinfile.ResolvedEntry{}},
 		}, nil
 	}
 
@@ -90,8 +91,10 @@ func (r *Resolver) Resolve(m *manifest.Manifest, opts ResolveOptions) (*ResolveR
 		selected = make(map[string]ResolvedDep)
 		for identity, deps := range byIdentity {
 			best := deps[0]
+			// Error ignored: URL was validated in collectDeps
 			bestParsed, _ := ParseDepURL(best.URL)
 			for _, dep := range deps[1:] {
+				// Error ignored: URL was validated in collectDeps
 				parsed, _ := ParseDepURL(dep.URL)
 				if semver.Compare(parsed.Version, bestParsed.Version) > 0 {
 					best = dep
@@ -100,6 +103,7 @@ func (r *Resolver) Resolve(m *manifest.Manifest, opts ResolveOptions) (*ResolveR
 			}
 			// Prefer direct dep metadata (Source == "") when available
 			for _, dep := range deps {
+				// Error ignored: URL was validated in collectDeps
 				depParsed, _ := ParseDepURL(dep.URL)
 				if depParsed.Version == bestParsed.Version && dep.Source == "" {
 					best.Alias = dep.Alias
@@ -114,6 +118,7 @@ func (r *Resolver) Resolve(m *manifest.Manifest, opts ResolveOptions) (*ResolveR
 		// a different version than what was first visited.
 		changed := false
 		for identity, dep := range selected {
+			// Error ignored: URL was validated in collectDeps
 			parsed, _ := ParseDepURL(dep.URL)
 			visitedVersion, ok := visited[identity]
 			if !ok || visitedVersion == parsed.Version {

--- a/internal/resolve/resolver_test.go
+++ b/internal/resolve/resolver_test.go
@@ -35,6 +35,9 @@ func TestResolveEmpty(t *testing.T) {
 	if len(result.Resolved) != 0 {
 		t.Errorf("Expected 0 resolved, got %d", len(result.Resolved))
 	}
+	if result.Resolved == nil {
+		t.Error("Expected non-nil empty slice for Resolved, got nil")
+	}
 }
 
 func TestResolveSingleDep(t *testing.T) {


### PR DESCRIPTION
- Updated Go version requirement in CONTRIBUTING.md from 1.24+ to 1.26+.
- Trimmed whitespace from CRAFT_TOKEN and GITHUB_TOKEN in auth.go to prevent issues with token validation.
- Added tests to ensure whitespace is trimmed from tokens and handled correctly in auth_test.go.
- Modified resolver.go to ensure Resolved is initialized as a non-nil slice.
- Added test to verify non-nil empty slice for Resolved in resolver_test.go.