### PR TITLE
[CLI Feature Bundle] Add list, tree, outdated commands, --verbose and --dry-run flags

### DIFF
--- a/.paw/work/cli-feature-bundle/CodeResearch.md
+++ b/.paw/work/cli-feature-bundle/CodeResearch.md
@@ -1,0 +1,338 @@
+---
+date: 2026-03-09T06:39:00Z
+git_commit: 97a78236715141dc86f122bdc46eb2ed81425db2
+branch: feature/cli-feature-bundle
+repository: erdemtuna/craft
+topic: "CLI Feature Bundle implementation map"
+tags: [research, codebase, cli, pinfile, manifest, ui, semver, fetch]
+status: complete
+last_updated: 2026-03-09
+---
+
+# Research: CLI Feature Bundle Implementation Map
+
+## Research Question
+
+Where and how do the existing CLI commands, data layer, UI components, and testing infrastructure work? What are the precise integration points for adding `craft list`, `craft tree`, `craft outdated`, `--verbose`, and `--dry-run`?
+
+## Summary
+
+The codebase follows clean Go conventions with Cobra for CLI, table-driven tests with mock interfaces, and well-separated packages. All building blocks for the five new features already exist — pinfile parsing, manifest parsing, tree rendering, tag listing, semver comparison, and atomic write helpers. The implementation primarily involves wiring existing components into new commands and adding interception points to existing ones.
+
+## Documentation System
+
+- **Framework**: Plain markdown (no generator)
+- **Docs Directory**: N/A — no dedicated docs folder
+- **Navigation Config**: N/A
+- **Style Conventions**: README.md has CLI reference table, command examples with code blocks; CONTRIBUTING.md covers development setup and testing patterns
+- **Build Command**: N/A
+- **Standard Files**: `README.md` (241 lines), `CONTRIBUTING.md` (193 lines), `CODE_OF_CONDUCT.md`, `LICENSE`; no CHANGELOG.md
+
+## Verification Commands
+
+- **Test Command**: `task test` → `go test -race ./...`
+- **Lint Command**: `task lint` → `golangci-lint run ./...` (12 linters)
+- **Build Command**: `task build` → `go build -ldflags "..." -o craft ./cmd/craft`
+- **Type Check**: N/A (Go compiler handles this during build)
+- **Full CI**: `task ci` → fmt:check → vet → lint → vuln → test → build
+
+## Detailed Findings
+
+### Root Command & Command Registration
+
+The root command is defined in `internal/cli/root.go`:
+- `rootCmd` variable declaration: `root.go:10-16`
+- Properties: `Use: "craft"`, `SilenceUsage: true`, `SilenceErrors: true`
+- No `PersistentPreRunE` or `PersistentFlags` defined
+- `init()` registers 8 subcommands: `root.go:18-27`
+- `Execute()` calls `rootCmd.Execute()`, prints errors to stderr: `root.go:30-36`
+
+Entry point: `cmd/craft/main.go:9-13` — calls `cli.Execute()`, exits with code 1 on error.
+
+### Command Pattern (version.go as template)
+
+Simple command structure in `internal/cli/version.go:8-16`:
+- Package-level `var versionCmd = &cobra.Command{...}`
+- Uses `Run` (no error return) for simple commands
+- Uses `cmd.Printf()` for output
+- No `init()` function needed when no flags
+
+Commands with side effects use `RunE` (returns error) — e.g., `install.go:26-32`, `update.go:23-29`.
+
+### Flag Registration Pattern
+
+Flags are registered in package-level `init()` functions with package-level variables:
+- `install.go:34-36`: `installCmd.Flags().StringVar(&installTarget, "target", "", "...")`
+- `update.go:31-33`: `updateCmd.Flags().StringVar(&updateTarget, "target", "", "...")`
+- No persistent/global flags exist on `rootCmd`
+
+### Install Command Flow
+
+Full flow in `internal/cli/install.go`:
+
+| Step | Line(s) | Function/Call |
+|------|---------|---------------|
+| Command definition | 26-32 | `var installCmd = &cobra.Command{...RunE: runInstall}` |
+| Flag registration | 34-36 | `init()` — `--target` flag |
+| Handler entry | 38 | `func runInstall(cmd *cobra.Command, args []string) error` |
+| Parse manifest | ~41-52 | `manifest.ParseFile()` |
+| Load existing pinfile | ~55-65 | `pinfile.ParseFile()` (optional) |
+| Create fetcher | 68-71 | `newFetcher()` |
+| Resolve dependencies | 75-78 | `resolver.Resolve(m, opts)` |
+| **Write pinfile** | **86** | `writePinfileAtomic(pfPath, result.Pinfile)` |
+| Resolve install targets | ~90-110 | `resolveInstallTargets(target)` |
+| Collect skill files | ~100-108 | `collectSkillFiles(fetcher, result)` |
+| Verify integrity | ~109-111 | `verifyIntegrity(result, skillFiles)` |
+| **Install to disk** | **112** | `installlib.Install(targetPath, skillFiles)` |
+| Print tree | 127 | `printDependencyTree(cmd, m, result)` |
+
+Dry-run interception point: after line 78 (resolve succeeds), before line 86 (first write).
+
+Helper functions:
+- `newFetcher()`: `install.go:327-337` — creates cache + GoGitFetcher
+- `writePinfileAtomic()`: `install.go:132-136` — wraps `writeAtomic()`
+- `writeAtomic()`: `atomic.go:11-31` — temp file + rename pattern
+- `printDependencyTree()`: `install.go:211-237` — builds `ui.DepNode` list, calls `ui.RenderTree()`
+- `collectSkillFiles()`: `install.go:239-282` — fetches all skill files from remote
+- `verifyIntegrity()`: `install.go:287-317` — SHA-256 digest check
+- `countSkills()`: `install.go:319-325` — counts total skills
+- `resolveInstallTargets()`: `install.go:141-174` — agent auto-detection or explicit path
+
+### Update Command Flow
+
+Full flow in `internal/cli/update.go`:
+
+| Step | Line(s) | Function/Call |
+|------|---------|---------------|
+| Command definition | 23-29 | `var updateCmd = &cobra.Command{...RunE: runUpdate}` |
+| Flag registration | 31-33 | `init()` — `--target` flag |
+| Handler entry | 35 | `func runUpdate(cmd *cobra.Command, args []string) error` |
+| List tags | 88 | `fetcher.ListTags(cloneURL)` |
+| Find latest | ~95 | `semver.FindLatest(tags)` |
+| Compare versions | 99 | `semver.Compare(current, latest)` |
+| Resolve deps | ~120-130 | `resolver.Resolve(m, opts)` |
+| **Write pinfile** | **143** | `writePinfileAtomic(pfPath, result.Pinfile)` |
+| **Write manifest** | **148** | `writeManifestAtomic(manifestPath, m)` |
+| Install to disk | 165 | `installlib.Install(targetPath, skillFiles)` |
+
+`writeManifestAtomic()`: `update.go:184-188` — same atomic write pattern.
+
+Dry-run interception point: after resolution succeeds, before line 143 (first write).
+
+### Pinfile Data Layer
+
+Types in `internal/pinfile/types.go`:
+- `Pinfile` struct: `types.go:6-13` — fields: `PinVersion int`, `Resolved map[string]ResolvedEntry`
+- `ResolvedEntry` struct: `types.go:16-32` — fields: `Commit`, `Integrity`, `Source`, `Skills []string`, `SkillPaths []string`
+- Map key for `Resolved` is the dependency URL (e.g., `github.com/org/repo`)
+
+Functions:
+- `ParseFile(path) (*Pinfile, error)`: `parse.go:27`
+- `Parse(r io.Reader) (*Pinfile, error)`: `parse.go:12`
+- `Write(p *Pinfile, w io.Writer) error`: `write.go:14`
+- `Validate(p *Pinfile) []error`: `validate.go:9`
+
+### Manifest Data Layer
+
+Types in `internal/manifest/types.go`:
+- `Manifest` struct: `types.go:6-30` — fields: `SchemaVersion`, `Name`, `Version`, `Description`, `License`, `Skills []string`, `Dependencies map[string]string`, `Metadata`
+- `Dependencies` type: `map[string]string` (alias → URL) at line 26
+
+Functions:
+- `ParseFile(path) (*Manifest, error)`: `parse.go:28`
+- `Parse(r io.Reader) (*Manifest, error)`: `parse.go:13`
+- `Write(m *Manifest, w io.Writer) error`: `write.go:14`
+
+### UI Tree Rendering
+
+In `internal/ui/tree.go`:
+- `DepNode` struct: `tree.go:11-15` — fields: `Alias string`, `URL string`, `Skills []string`
+- `RenderTree(w io.Writer, packageName string, localSkills []string, deps []DepNode)`: `tree.go:19`
+- `FormatTree(packageName, localSkills, deps) string`: `tree.go:71`
+- Deps sorted by `Alias` ascending: `tree.go:42-47` using `sort.Slice()`
+- Uses box-drawing characters: `├──`, `└──`, `│`
+
+### UI Progress
+
+In `internal/ui/progress.go`:
+- `Progress` struct: `progress.go:16-20` — fields: `w io.Writer`, `isTTY bool`, `mu sync.Mutex`
+- `NewProgress() *Progress`: `progress.go:24` — uses `term.IsTerminal(int(os.Stderr.Fd()))` for TTY detection
+- `IsTTY() bool`: `progress.go:87`
+- Non-TTY: suppresses progress output entirely (CI-friendly)
+
+### Semver Package
+
+In `internal/semver/semver.go`:
+- `Compare(a, b string) int`: `semver.go:11` — returns -1, 0, or 1
+- `ParseParts(v string) [3]int`: `semver.go:27` — extracts [major, minor, patch] using `fmt.Sscanf`
+- `FindLatest(tags []string) string`: `semver.go:36` — filters `v`-prefixed tags, rejects pre-release (`-`/`+`), returns highest
+
+Version handling:
+- Tags must start with `v` prefix: `semver.go:41`
+- V-prefix stripped: `tag[1:]` at `semver.go:44`
+- Pre-release/build metadata rejected: `strings.ContainsAny(version, "-+")` at `semver.go:46`
+
+### Fetch Layer
+
+Interface in `internal/fetch/fetcher.go:7-22`:
+```
+GitFetcher interface {
+    ResolveRef(url, ref string) (commitSHA string, err error)
+    ListTags(url string) ([]string, error)
+    ListTree(url, commitSHA string) ([]string, error)
+    ReadFiles(url, commitSHA string, paths []string) (map[string][]byte, error)
+}
+```
+
+Implementation:
+- `NewGoGitFetcher(cache *Cache) *GoGitFetcher`: `gogit.go:30`
+- `NewCache(root string) (*Cache, error)`: `cache.go:21`
+- `DefaultCacheRoot() (string, error)`: `cache.go:29` — returns `~/.craft/cache`
+
+Mock for testing:
+- `MockFetcher` struct: `fetch/mock.go` — implements `GitFetcher` with configurable maps (`Refs`, `TagsByURL`, `Trees`, `Files`, `Errors`)
+
+### Error Handling Pattern
+
+Commands return errors via `RunE`; errors flow upward:
+1. `RunE` returns `fmt.Errorf("context: %w", err)` — e.g., `install.go:41,50,52,81,86,114`
+2. Cobra receives error but doesn't print (due to `SilenceErrors: true`)
+3. `Execute()` in `root.go:30-36` prints error to stderr
+4. `main()` in `cmd/craft/main.go:10-11` calls `os.Exit(1)` on non-nil error
+
+### Testing Infrastructure
+
+**CLI test pattern** (`internal/cli/cli_test.go:11-46`):
+- Cobra command testing: `rootCmd.SetOut(buf)` → `rootCmd.SetArgs(args)` → `rootCmd.Execute()`
+- Output validation via buffer contents
+- Used for `TestVersionCommand` (line 11) and `TestRootHelp` (line 30)
+
+**Test helpers** (`internal/cli/add_test.go:11-35`):
+- `testChdir(t, dir)`: changes dir with cleanup (line 11)
+- `testWriteFile(t, path, data)`: writes test files (line 23)
+- `testMkdirAll(t, path)`: creates directories (line 30)
+
+**Mock fetcher** (`internal/fetch/mock.go`):
+- `MockFetcher` with maps: `Refs`, `TagsByURL`, `Trees`, `Files`, `Errors`
+- Used extensively in `install_test.go` and `update_test.go`
+
+**Test files by package**:
+
+| Package | Test Files | Lines |
+|---------|-----------|-------|
+| `internal/cli/` | 7 files: add, cache, cli, install, remove, update, validate | ~1,234 |
+| `internal/pinfile/` | 3 files: parse, validate, write | ~398 |
+| `internal/manifest/` | 3 files: parse, validate, write | ~495 |
+| `internal/ui/` | 2 files: progress, tree | ~100 |
+| `internal/semver/` | 1 file: semver | ~100 |
+| `internal/fetch/` | 3 files: auth, cache, fetcher | ~200 |
+
+**Testdata fixtures** at `testdata/`:
+- `manifests/`: minimal.yaml, valid.yaml, with-extras.yaml
+- `pinfiles/`: valid.yaml
+- `packages/`: 7 package fixtures (collision, escape, missing-skill, pinfile-mismatch, pinfile-no-deps, valid, no-manifest)
+- `skills/`: 5 SKILL.md fixtures
+
+### Data Flow for New Commands
+
+**craft list** data flow:
+1. `manifest.ParseFile("craft.yaml")` → get `Dependencies` map (alias → URL) and package `Name`/`Version`
+2. `pinfile.ParseFile("craft.pin.yaml")` → get `Resolved` map (URL → ResolvedEntry with Skills)
+3. Join on URL: for each manifest dependency alias/URL, look up pinfile entry to get version (from commit tag) and skills
+4. Sort by alias, print table
+
+**Observation**: The pinfile `Resolved` map is keyed by URL, and the `ResolvedEntry` does not store the resolved version tag directly — it stores `Commit` (SHA). To display versions, we need to either:
+- Store version info during resolution (not currently done in pinfile)
+- Re-derive version from tags (expensive)
+- Parse version from the dependency URL if it includes a version constraint
+
+This is a constraint that affects `craft list` and `craft outdated` design. The manifest `Dependencies` map stores `alias → URL` where URL may include a version constraint (e.g., `github.com/org/repo@v1.0.0`).
+
+**craft tree** data flow:
+1. Same as list: parse manifest + pinfile
+2. Build `[]ui.DepNode` from joined data
+3. Call `ui.RenderTree(os.Stdout, packageName, localSkills, deps)`
+
+**craft outdated** data flow:
+1. Parse manifest + pinfile (same join)
+2. For each direct dependency URL: `fetcher.ListTags(url)` → `semver.FindLatest(tags)`
+3. Compare pinned version vs latest: `semver.Compare()`
+4. Classify: compare `ParseParts()` results to determine major/minor/patch
+5. Print table, exit code 1 if any outdated
+
+## Code References
+
+- `internal/cli/root.go:10-16` — Root command definition
+- `internal/cli/root.go:18-27` — Command registration
+- `internal/cli/root.go:30-36` — Execute function
+- `internal/cli/version.go:8-16` — Simple command template
+- `internal/cli/install.go:26-32` — Install command definition
+- `internal/cli/install.go:38` — runInstall handler
+- `internal/cli/install.go:75-78` — Resolver.Resolve call
+- `internal/cli/install.go:86` — writePinfileAtomic (dry-run boundary)
+- `internal/cli/install.go:112` — installlib.Install (dry-run boundary)
+- `internal/cli/install.go:127` — printDependencyTree
+- `internal/cli/install.go:211-237` — printDependencyTree implementation
+- `internal/cli/install.go:327-337` — newFetcher helper
+- `internal/cli/update.go:23-29` — Update command definition
+- `internal/cli/update.go:35` — runUpdate handler
+- `internal/cli/update.go:88` — ListTags call
+- `internal/cli/update.go:99` — semver.Compare call
+- `internal/cli/update.go:143` — writePinfileAtomic (dry-run boundary)
+- `internal/cli/update.go:148` — writeManifestAtomic (dry-run boundary)
+- `internal/cli/update.go:165` — installlib.Install (dry-run boundary)
+- `internal/cli/atomic.go:11-31` — writeAtomic helper
+- `internal/pinfile/types.go:6-13` — Pinfile struct
+- `internal/pinfile/types.go:16-32` — ResolvedEntry struct
+- `internal/pinfile/parse.go:12,27` — Parse, ParseFile
+- `internal/manifest/types.go:6-30` — Manifest struct
+- `internal/manifest/parse.go:13,28` — Parse, ParseFile
+- `internal/ui/tree.go:11-15` — DepNode struct
+- `internal/ui/tree.go:19` — RenderTree function
+- `internal/ui/tree.go:71` — FormatTree function
+- `internal/ui/progress.go:16-20` — Progress struct
+- `internal/ui/progress.go:24` — NewProgress (TTY detection)
+- `internal/semver/semver.go:11` — Compare function
+- `internal/semver/semver.go:27` — ParseParts function
+- `internal/semver/semver.go:36` — FindLatest function
+- `internal/fetch/fetcher.go:7-22` — GitFetcher interface
+- `internal/fetch/gogit.go:30` — NewGoGitFetcher
+- `internal/fetch/cache.go:21,29` — NewCache, DefaultCacheRoot
+- `internal/fetch/mock.go` — MockFetcher for testing
+- `internal/cli/cli_test.go:11-46` — Cobra command test pattern
+- `internal/cli/add_test.go:11-35` — Test helper functions
+- `Taskfile.yml:21-24` — test task
+- `Taskfile.yml:49-52` — lint task
+- `Taskfile.yml:16-19` — build task
+- `Taskfile.yml:59-67` — ci task (full pipeline)
+
+## Architecture Documentation
+
+**Command registration**: Package-level `var xCmd = &cobra.Command{...}` + `init()` for flags + `rootCmd.AddCommand(xCmd)` in `root.go init()`.
+
+**Data flow pattern**: Commands call `manifest.ParseFile()` and `pinfile.ParseFile()` to load state, use `fetch` layer for remote operations, and `ui` layer for output.
+
+**Atomic writes**: All file mutations use `writeAtomic()` (temp file + `os.Rename`) to prevent partial writes.
+
+**Testing convention**: Table-driven tests, `MockFetcher` for network isolation, `testdata/` fixtures for YAML parsing, `rootCmd.SetArgs()`/`Execute()` for command integration tests.
+
+**Dependency URL format**: Manifest stores `alias → URL` where URL may include version constraint. Pinfile stores `URL → ResolvedEntry` with commit SHA but no version tag.
+
+### Resolve Layer Types
+
+In `internal/resolve/types.go`:
+- `ResolvedDep` struct: `types.go:4-26` — fields: `URL` (full URL with version, e.g., `github.com/example/skills@v1.0.0`), `Alias`, `Commit`, `Integrity`, `Skills []string`, `SkillPaths []string`, `Source`
+- `ResolveResult` struct: `resolver.go:44-50` — fields: `Resolved []ResolvedDep`, `Pinfile *pinfile.Pinfile`
+
+In `internal/resolve/depurl.go`:
+- `DepURL` struct: `depurl.go:15-30` — parsed URL with `Host`, `Org`, `Repo`, `Version` (without v-prefix)
+- `ParseDepURL(raw string) (*DepURL, error)`: `depurl.go:34` — parses `host/org/repo@vMAJOR.MINOR.PATCH`
+- `PackageIdentity() string`: `depurl.go:52` — returns `host/org/repo` (no version)
+- `GitTag() string`: `depurl.go:57` — returns `v` + version
+- `WithVersion(version string) string`: `depurl.go:73` — creates new URL with different version
+
+**Version in pinfile keys**: The pinfile `Resolved` map key **includes the version** (e.g., `github.com/example/git-skills@v1.0.0` — see `testdata/pinfiles/valid.yaml:4`). Version is directly extractable via `ParseDepURL()` on the key. This resolves the version display question for `craft list` and `craft outdated`.
+
+## Open Questions
+
+None — all implementation details are mapped.

--- a/.paw/work/cli-feature-bundle/Docs.md
+++ b/.paw/work/cli-feature-bundle/Docs.md
@@ -1,0 +1,233 @@
+# CLI Feature Bundle
+
+## Overview
+
+Five CLI features added to bring craft to package-manager parity: dependency listing (`craft list`), dependency tree visualization (`craft tree`), update checking (`craft outdated`), verbose diagnostic output (`--verbose`), and safe operation preview (`--dry-run`). All features are additive — no existing behavior was changed.
+
+These features close the ergonomic gap between craft and established package managers like npm, cargo, and go modules. Users can now inspect dependency state, assess update risk, debug resolution issues, and preview operations without reading raw YAML or risking unintended changes.
+
+## Architecture and Design
+
+### High-Level Architecture
+
+All five features integrate into the existing Cobra CLI layer (`internal/cli/`) and reuse the established data and fetch packages:
+
+```
+┌─────────────────────────────────────────────────┐
+│ New Commands          │ Modified Commands        │
+│ list.go               │ install.go (--dry-run)   │
+│ tree.go               │ update.go  (--dry-run)   │
+│ outdated.go           │                          │
+├───────────────────────┴──────────────────────────┤
+│ Shared Infrastructure                            │
+│ helpers.go  (requireManifestAndPinfile,           │
+│              printDryRunSummary)                  │
+│ verbose.go  (verboseLog, sanitize)               │
+│ root.go     (--verbose flag, silentExitError,    │
+│              ExitCode)                           │
+├──────────────────────────────────────────────────┤
+│ Existing Packages (unchanged)                    │
+│ manifest  pinfile  ui  fetch  semver  resolve    │
+└──────────────────────────────────────────────────┘
+```
+
+**Data flow pattern**: Read-only commands (`list`, `tree`, `outdated`) call `requireManifestAndPinfile()` to load both files, then join/transform the data for display. `outdated` additionally uses `newFetcher()` for remote tag listing.
+
+### Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Data source for `list`/`tree` | Pinfile (`craft.pin.yaml`) | Like `go list -m all`. Avoids requiring target detection. Pinfile is source of truth after install. |
+| Data source for `outdated` | Manifest (`craft.yaml`) direct deps | Only the user's declared dependencies are checked. Transitive deps are managed by their parent packages. |
+| Verbosity model | `--verbose` only (2 levels) | Go-style simplicity. Non-TTY already suppresses progress output, so `--quiet` isn't needed. |
+| `outdated` exit code | 1 when updates available | CI scripts can use `craft outdated || echo "updates"`. Standard pattern (npm, pip). |
+| `--dry-run` scope | `install` and `update` only | These are the commands with filesystem side effects. `add`/`remove` modify `craft.yaml` which is a different risk profile. |
+| `silentExitError` pattern | Type-checked error with exit code | Allows `outdated` to signal exit code 1 without printing an error message. `ExitCode()` helper lets `main.go` extract the intended code. |
+| Terminal sanitization | `sanitize()` strips control chars | Dependency aliases, URLs, and skill names come from YAML files that could contain ANSI escape sequences. All user-controlled strings are sanitized before terminal output. |
+| `tree` output destination | stdout (not stderr) | `craft tree` is a standalone command whose primary purpose IS the tree. Install's tree goes to stderr because it's decorative feedback alongside the real operation. |
+
+### Integration Points
+
+- **`requireManifestAndPinfile()`** (`helpers.go`): Shared loader for list/tree/outdated. Returns hard error on missing files — distinct from install/update which tolerate absent pinfiles.
+- **`printDryRunSummary()`** (`helpers.go`): Shared formatter for install/update dry-run output.
+- **`sanitize()`** (`verbose.go`): Terminal escape stripping, used by list, outdated, and dry-run summary.
+- **`ExitCode()`** (`root.go`): Extracts exit code from `silentExitError` for `main.go`.
+- **`newFetcher()`** (`install.go`): Reused by `outdated` for remote tag listing. Pre-existing shared helper.
+- **`ui.RenderTree()`** (`internal/ui/tree.go`): Reused by `craft tree` — the rendering code already existed, this PR just wires it to a standalone command.
+
+## User Guide
+
+### Prerequisites
+
+- A craft project with `craft.yaml` (created by `craft init`)
+- For `list`, `tree`, `outdated`: a `craft.pin.yaml` must exist (created by `craft install`)
+- For `outdated`: network access to dependency remotes
+
+### Basic Usage
+
+**List resolved dependencies:**
+```bash
+$ craft list
+company-standards  v2.1.0  (2 skills)
+utility-skills     v1.0.0  (1 skill)
+
+# Extended info with URLs and skill names
+$ craft list --detailed
+company-standards  v2.1.0  github.com/org/standards
+  skills: api-conventions, error-formats
+```
+
+**View dependency tree:**
+```bash
+$ craft tree
+my-package@1.0.0
+├── Local skills
+│   ├── skill-a
+│   └── skill-b
+└── company-standards (github.com/org/standards@v2.1.0)
+    ├── api-conventions
+    └── error-formats
+```
+
+**Check for updates:**
+```bash
+$ craft outdated
+company-standards  v2.1.0 → v2.2.0  (minor)
+utility-skills     v1.0.0            (up to date)
+
+$ echo $?
+1  # non-zero when updates available
+```
+
+**Preview operations:**
+```bash
+$ craft install --dry-run
+Would resolve 2 dependency(ies):
+  + company-standards  v2.1.0  (2 skills: api-conventions, error-formats)
+  + utility-skills     v1.0.0  (1 skill: git-helper)
+
+No changes made.
+```
+
+**Debug with verbose output:**
+```bash
+$ craft outdated --verbose
+No pinfile entry for new-dep, using manifest version v1.0.0
+Fetching tags from https://github.com/org/repo.git...
+Found 5 tags for company-standards
+Fetching tags from https://github.com/org/utils.git...
+Found 3 tags for utility-skills
+```
+
+### Advanced Usage
+
+**CI integration with `outdated`:**
+```bash
+# Fail CI if dependencies are outdated
+craft outdated || { echo "Dependencies need updating"; exit 1; }
+```
+
+**Pipe-friendly output:**
+```bash
+# craft tree output goes to stdout (pipe-friendly)
+craft tree | grep "api-conventions"
+
+# craft list output goes to stdout
+craft list | wc -l  # count dependencies
+```
+
+**Combining flags:**
+```bash
+# Verbose dry-run shows resolution steps without making changes
+craft install --dry-run --verbose
+```
+
+## API Reference
+
+### Key Components
+
+**`requireManifestAndPinfile() (*manifest.Manifest, *pinfile.Pinfile, error)`**
+Loads both `craft.yaml` and `craft.pin.yaml` from the working directory. Returns user-friendly errors when either file is missing. Used by list, tree, and outdated commands.
+
+**`sanitize(s string) string`**
+Strips control characters (except tab and newline) from strings. Use on any user-controlled data before terminal output to prevent escape injection.
+
+**`verboseLog(cmd *cobra.Command, format string, args ...any)`**
+Writes formatted message to stderr when `--verbose` is enabled. No-op otherwise.
+
+**`ExitCode(err error) int`**
+Returns the exit code from a `silentExitError`, or 1 for any other error. Used by `main.go` to propagate intended exit codes.
+
+**`classifyUpdate(current, latest string) string`**
+Returns `"major"`, `"minor"`, or `"patch"` based on which semver component changed between two version strings.
+
+### Configuration Options
+
+| Environment Variable | Effect on New Commands |
+|---------------------|----------------------|
+| `CRAFT_TOKEN` | Used by `outdated` when fetching remote tags from trusted hosts |
+| `GITHUB_TOKEN` | Fallback for `outdated` on github.com when `CRAFT_TOKEN` not set |
+| `CRAFT_TOKEN_HOSTS` | Restricts which hosts receive `CRAFT_TOKEN` during `outdated` checks |
+
+| Flag | Commands | Effect |
+|------|----------|--------|
+| `--verbose`, `-v` | All | Enables diagnostic output to stderr |
+| `--dry-run` | `install`, `update` | Prevents file writes, shows preview |
+| `--detailed` | `list` | Shows URLs and individual skill names |
+
+## Testing
+
+### How to Test
+
+**Quick smoke test:**
+```bash
+cd your-craft-project
+craft list                    # Should show resolved deps
+craft tree                    # Should show ASCII tree
+craft outdated                # Should check for updates (needs network)
+craft install --dry-run       # Should show preview, no files changed
+craft version --verbose       # Should accept flag without error
+```
+
+**Verify dry-run safety:**
+```bash
+rm -f craft.pin.yaml
+craft install --dry-run       # Should error: no deps to install (if no deps)
+                              # OR show preview without creating craft.pin.yaml
+ls craft.pin.yaml             # Should not exist
+```
+
+**Verify exit codes:**
+```bash
+craft outdated; echo "exit: $?"  # 1 if updates available, 0 if current
+```
+
+### Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| No `craft.pin.yaml` | list/tree/outdated error with "run `craft install` first" |
+| No `craft.yaml` | All commands error with "run `craft init` first" |
+| Zero dependencies | list: "No dependencies resolved." / outdated: "No dependencies to check." |
+| Dependency with no semver tags | outdated: skipped with warning, not shown as "(up to date)" |
+| Pinned version tag absent from remote | outdated: warning printed, still shows current + latest |
+| Network failure for one dependency | outdated: error for that dep, continues checking others, exit 1 |
+| Single skill | list: "(1 skill)" singular, not "(1 skills)" |
+| Zero skills | list --detailed: "(none)" / dry-run: "(0 skills)" |
+| ANSI escapes in dependency names | Stripped by `sanitize()` before display |
+
+## Limitations and Future Work
+
+**Current limitations:**
+- `craft outdated` fetches tags sequentially — could be slow with many dependencies. Parallel fetching is a future optimization.
+- No `--quiet` flag — non-TTY already suppresses progress, but explicit quiet mode could be added later.
+- No JSON/machine-readable output format — all output is human-readable text.
+- `--dry-run` is not available on `add` or `remove` (these only modify `craft.yaml`, a different risk profile).
+- `CRAFT_TOKEN` default-allow policy for unknown hosts is a pre-existing security concern (see `internal/fetch/auth.go`). Setting `CRAFT_TOKEN_HOSTS` is recommended in shared/CI environments.
+
+**Possible future work:**
+- `--format json` for machine-readable output
+- `--quiet` flag for suppressing all non-error output
+- Parallel tag fetching in `craft outdated`
+- `craft search` for discovering available skill packages
+- Default-deny for `CRAFT_TOKEN` on unknown hosts (breaking change, needs version bump)

--- a/.paw/work/cli-feature-bundle/ImplementationPlan.md
+++ b/.paw/work/cli-feature-bundle/ImplementationPlan.md
@@ -1,0 +1,285 @@
+# CLI Feature Bundle Implementation Plan
+
+## Overview
+
+Add five CLI features to bring craft to package-manager parity: `craft list` (show resolved dependencies), `craft tree` (standalone dependency tree), `craft outdated` (preview available updates), `--verbose` global flag (diagnostic output), and `--dry-run` on install/update (safe preview). All features are additive — no existing behavior changes.
+
+## Current State Analysis
+
+- **CLI layer** (`internal/cli/`): 8 commands registered via Cobra. No persistent/global flags on rootCmd. Commands use `RunE` pattern returning errors. Output via `cmd.Printf()` (stdout) and `fmt.Fprintf(os.Stderr)` (errors/progress).
+- **Data layer**: `pinfile.ParseFile()` and `manifest.ParseFile()` provide all dependency state. Pinfile keys include version (`github.com/org/repo@v1.0.0`), extractable via `resolve.ParseDepURL()`.
+- **UI layer**: `ui.RenderTree()` exists and is standalone-ready. `ui.Progress` handles TTY detection. No verbosity mechanism.
+- **Fetch/semver**: `fetcher.ListTags()` + `semver.FindLatest()` + `semver.Compare()` + `semver.ParseParts()` provide everything needed for outdated checks.
+- **Install/update flows**: Clean interception points exist — resolution completes before any writes. `writePinfileAtomic()` at install.go:86, `installlib.Install()` at install.go:112. Update similarly at update.go:143/148/165.
+- **Testing**: Table-driven tests, `MockFetcher` for network isolation, Cobra tests via `rootCmd.SetArgs()`/`Execute()`, testdata fixtures.
+
+## Desired End State
+
+Five new capabilities available in craft CLI:
+- `craft list` and `craft list --detailed` show resolved dependency state from pinfile
+- `craft tree` shows standalone ASCII dependency tree
+- `craft outdated` checks remote for updates, classifies risk, exits 1 when outdated
+- `--verbose` / `-v` available on all commands for diagnostic output
+- `craft install --dry-run` and `craft update --dry-run` preview operations without writes
+
+Verification: `task ci` passes (fmt, vet, lint, vuln, test, build). All new commands have unit tests. README updated with new commands.
+
+## What We're NOT Doing
+
+- `--quiet` flag (non-TTY already suppresses progress)
+- `--dry-run` on `add` or `remove` commands
+- JSON or machine-readable output format
+- `craft search` or registry browsing
+- Colored output or ANSI formatting
+- `--format` flag for custom output templates
+- On-disk installation verification for `craft list`
+- Parallel fetching for `craft outdated` (sequential is acceptable for v1)
+- Checking transitive dependencies in `craft outdated`
+
+## Phase Status
+- [ ] **Phase 1: Verbose flag infrastructure** - Add global `--verbose` flag and verbosity helper
+- [ ] **Phase 2: craft list command** - Show resolved dependencies from pinfile
+- [ ] **Phase 3: craft tree command** - Standalone dependency tree visualization
+- [ ] **Phase 4: craft outdated command** - Check for available updates with semver classification
+- [ ] **Phase 5: Dry-run on install and update** - Preview operations without side effects
+- [ ] **Phase 6: Documentation** - README updates and Docs.md
+
+## Phase Candidates
+<!-- No deferred candidates — all features are committed for this bundle -->
+
+---
+
+## Phase 1: Verbose flag infrastructure
+
+### Objective
+Add a global `--verbose` / `-v` persistent flag on rootCmd and a package-level helper that commands can query. This is the foundation phase — later phases will emit verbose output through this mechanism.
+
+### Changes Required
+
+- **`internal/cli/root.go`**: Add `var verbose bool` package-level variable. Register `--verbose` / `-v` as a `PersistentBoolVar` on `rootCmd` in `init()`. This makes the flag available to all subcommands automatically.
+
+- **`internal/cli/verbose.go`** (new file): Create a small helper for verbose output. Provide a `verboseLog(cmd *cobra.Command, format string, args ...any)` function that writes to `cmd.ErrOrStderr()` only when `verbose` is true. Prefix verbose lines with a distinguishing marker (e.g., no prefix — just the message, since it goes to stderr and only appears with `--verbose`). Follow the pattern of `printDependencyTree()` which writes to `cmd.ErrOrStderr()`.
+
+- **Tests — `internal/cli/verbose_test.go`** (new file): Test that `verboseLog` writes to stderr when verbose is true and suppresses when false. Test that `--verbose` and `-v` are accepted by rootCmd without error.
+
+- **Tests — `internal/cli/cli_test.go`**: Add a test verifying `--verbose` flag is accepted on a command (e.g., `craft version --verbose` does not error).
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] Tests pass: `task test`
+- [ ] Lint clean: `task lint`
+- [ ] Build succeeds: `task build`
+
+#### Manual Verification:
+- [ ] `./craft version --verbose` runs without error
+- [ ] `./craft version -v` runs without error (shorthand)
+- [ ] `./craft --verbose version` runs without error (persistent flag before subcommand)
+- [ ] Default behavior unchanged — no verbose output without the flag
+
+---
+
+## Phase 2: craft list command
+
+### Objective
+Add `craft list` command that reads manifest + pinfile and prints a summary table of resolved dependencies. Support `--detailed` flag for extended output.
+
+### Changes Required
+
+- **`internal/cli/list.go`** (new file): New cobra command `listCmd` with `Use: "list"`, `Short: "List resolved dependencies"`, `RunE: runList`. Register `--detailed` bool flag. Implementation:
+  1. Parse manifest via `manifest.ParseFile("craft.yaml")` — get `Dependencies` map (alias → URL) and package metadata
+  2. Parse pinfile via `pinfile.ParseFile("craft.pin.yaml")` — get `Resolved` map
+  3. Handle missing pinfile → error with "run 'craft install' first" suggestion
+  4. Handle zero dependencies → print "No dependencies resolved." and return nil
+  5. Join data: for each manifest dependency, find matching pinfile entry by URL key. Extract version via `resolve.ParseDepURL()` on the pinfile key
+  6. Sort entries alphabetically by alias
+  7. Default format: `alias  vX.Y.Z  (N skills)` — aligned columns using `fmt.Fprintf` with `tabwriter` or manual padding
+  8. Detailed format: alias, version, source URL, then indented skill names on next lines
+  9. Emit verbose output for each dependency lookup when `--verbose` is set
+
+- **`internal/cli/root.go`**: Add `rootCmd.AddCommand(listCmd)` in `init()`.
+
+- **Tests — `internal/cli/list_test.go`** (new file): Test scenarios from Spec.md:
+  1. List with resolved dependencies shows table (default format)
+  2. List with `--detailed` shows extended output
+  3. List with no pinfile returns error with helpful message
+  4. List with zero dependencies shows "No dependencies resolved."
+  5. Use `testdata/` fixtures or inline manifest+pinfile setup via `testWriteFile()`
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] Tests pass: `task test`
+- [ ] Lint clean: `task lint`
+
+#### Manual Verification:
+- [ ] `./craft list` in a project with dependencies shows a clean table
+- [ ] `./craft list --detailed` shows URLs and skill names
+- [ ] `./craft list` with no `craft.pin.yaml` shows actionable error
+- [ ] `./craft list --verbose` shows additional diagnostic output
+
+---
+
+## Phase 3: craft tree command
+
+### Objective
+Wire existing `ui.RenderTree()` to a standalone `craft tree` command. This is the smallest phase — primarily wiring code.
+
+### Changes Required
+
+- **`internal/cli/tree.go`** (new file): New cobra command `treeCmd` with `Use: "tree"`, `Short: "Print dependency tree"`, `RunE: runTree`. Implementation:
+  1. Parse manifest — get package name, version, local skills
+  2. Parse pinfile — get resolved dependencies
+  3. Handle missing pinfile → same error pattern as `craft list`
+  4. Build `[]ui.DepNode` from pinfile data — follow exact pattern from `printDependencyTree()` at `install.go:211-237`
+  5. Extract local skill names from manifest `Skills` paths — same logic as `install.go:218-223`
+  6. Call `ui.RenderTree(cmd.OutOrStdout(), packageName, localSkills, deps)` — note: write to stdout (not stderr like install does) since this is the primary output, not a side effect
+
+- **`internal/cli/root.go`**: Add `rootCmd.AddCommand(treeCmd)` in `init()`.
+
+- **Tests — `internal/cli/tree_test.go`** (new file): Test scenarios:
+  1. Tree with dependencies shows full tree with box-drawing characters
+  2. Tree with no dependencies shows package and local skills only
+  3. Tree with no pinfile returns error
+  4. Verify output goes to stdout (capture via `cmd.SetOut()`)
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] Tests pass: `task test`
+- [ ] Lint clean: `task lint`
+
+#### Manual Verification:
+- [ ] `./craft tree` in a project with dependencies shows ASCII tree
+- [ ] Output matches the format from `craft install` tree rendering
+
+---
+
+## Phase 4: craft outdated command
+
+### Objective
+Add `craft outdated` command that checks each direct dependency against its remote repository for newer versions, classifies update type (major/minor/patch), and exits with code 1 when updates are available.
+
+### Changes Required
+
+- **`internal/cli/outdated.go`** (new file): New cobra command `outdatedCmd` with `Use: "outdated"`, `Short: "Show available dependency updates"`, `RunE: runOutdated`. Implementation:
+  1. Parse manifest + pinfile (same pattern as list/tree)
+  2. Handle missing pinfile, zero dependencies (same error patterns)
+  3. Create fetcher via `newFetcher()` (reuse helper from `install.go:327-337` — may need to move to a shared location or keep as-is since it's package-level)
+  4. For each direct dependency (from manifest `Dependencies` map):
+     a. Extract current version from pinfile key via `resolve.ParseDepURL()`
+     b. Compute clone URL via `DepURL.HTTPSURL()` or `fetch.NormalizeCloneURL()`
+     c. Call `fetcher.ListTags(cloneURL)` — wrap in error handling per-dependency
+     d. Call `semver.FindLatest(tags)` — skip if no semver tags (warn)
+     e. Compare via `semver.Compare(current, latest)` — skip if up to date
+     f. Classify update type by comparing `semver.ParseParts()` results: if major differs → "major", else if minor differs → "minor", else → "patch"
+  5. Print results sorted by alias: outdated deps show `alias  vCurrent → vLatest  (type)`, up-to-date deps show `alias  vCurrent  (up to date)`
+  6. Track whether any dep is outdated — if so, return a sentinel error or use `os.Exit(1)` pattern
+  7. Verbose output: log each fetch operation, version comparison result
+
+- **Exit code handling**: The current error flow (`RunE` returns error → `Execute()` prints to stderr → `main()` exits 1) would print an error message for exit code 1. For `craft outdated`, exit 1 should be silent (just the exit code). Options:
+  - Define a sentinel error type (e.g., `type exitError struct{ code int }`) that `Execute()` recognizes and doesn't print
+  - Or have `runOutdated` call `os.Exit(1)` directly (simpler but less testable)
+  - **Recommended**: Sentinel error approach — define `type silentExitError struct{ code int }` in a new file or in `root.go`, check for it in `Execute()` before printing. This keeps the error flow clean and testable.
+
+- **`internal/cli/root.go`**: Add `rootCmd.AddCommand(outdatedCmd)` in `init()`. Update `Execute()` to check for `silentExitError` before printing.
+
+- **Tests — `internal/cli/outdated_test.go`** (new file): Test scenarios using `MockFetcher`:
+  1. One outdated dependency → shows update with classification, exit 1
+  2. All up to date → shows "(up to date)" for all, exit 0
+  3. No pinfile → error
+  4. Zero dependencies → "No dependencies to check." message
+  5. Fetch failure for one dep → error for that dep, continue checking others, exit 1
+  6. Dependency with no semver tags → skip with warning
+  7. Major/minor/patch classification correctness
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] Tests pass: `task test`
+- [ ] Lint clean: `task lint`
+
+#### Manual Verification:
+- [ ] `./craft outdated` shows update status for each dependency
+- [ ] Exit code is 1 when updates available, 0 when all current
+- [ ] Network failures for individual deps don't block other checks
+- [ ] `./craft outdated --verbose` shows fetch operations
+
+---
+
+## Phase 5: Dry-run on install and update
+
+### Objective
+Add `--dry-run` flag to `craft install` and `craft update` that runs full resolution but prevents all file writes and installation.
+
+### Changes Required
+
+- **`internal/cli/install.go`**: 
+  1. Add `var installDryRun bool` package-level variable
+  2. Register `--dry-run` flag in `init()`: `installCmd.Flags().BoolVar(&installDryRun, "dry-run", false, "...")`
+  3. In `runInstall()`, after `resolver.Resolve()` succeeds (after line 78), check `installDryRun`. If true:
+     a. Print dry-run summary: "Would resolve N dependencies:" followed by each dependency with alias, version, skill count
+     b. Print "Would install to: <targetPath>" (still resolve target for informational purposes, but skip actual install)
+     c. Print "No changes made."
+     d. Return nil (skip `writePinfileAtomic`, `collectSkillFiles`, `verifyIntegrity`, `installlib.Install`, `printDependencyTree`)
+  4. Verbose output in dry-run: show resolution steps
+
+- **`internal/cli/update.go`**:
+  1. Add `var updateDryRun bool` package-level variable
+  2. Register `--dry-run` flag in `init()`: `updateCmd.Flags().BoolVar(&updateDryRun, "dry-run", false, "...")`
+  3. In `runUpdate()`, after resolution succeeds, check `updateDryRun`. If true:
+     a. Print dry-run summary: what would be updated (version changes), what would stay the same
+     b. Print "No changes made."
+     c. Return nil (skip `writePinfileAtomic`, `writeManifestAtomic`, `installlib.Install`)
+
+- **Tests — `internal/cli/install_test.go`**: Add dry-run test scenarios:
+  1. `install --dry-run` produces summary output
+  2. `install --dry-run` does NOT write `craft.pin.yaml` (verify file doesn't exist/isn't modified)
+  3. `install --dry-run` does NOT install to target
+
+- **Tests — `internal/cli/update_test.go`**: Add dry-run test scenarios:
+  1. `update --dry-run` produces summary output
+  2. `update --dry-run` does NOT modify `craft.pin.yaml` or `craft.yaml`
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] Tests pass: `task test`
+- [ ] Lint clean: `task lint`
+
+#### Manual Verification:
+- [ ] `./craft install --dry-run` shows what would be resolved without writing files
+- [ ] `./craft update --dry-run` shows what would change without modifying anything
+- [ ] `./craft install --dry-run --verbose` shows resolution steps plus dry-run summary
+- [ ] Verify no files created: `ls craft.pin.yaml` after dry-run in clean project should fail
+
+---
+
+## Phase 6: Documentation
+
+### Objective
+Update README.md with new commands and flags. Create Docs.md technical reference.
+
+### Changes Required
+
+- **`.paw/work/cli-feature-bundle/Docs.md`**: Technical reference covering all five features — architecture decisions, component interactions, testing approach, usage examples. Load `paw-docs-guidance` skill for template.
+
+- **`README.md`**: Update the Commands table (around line 128) to include `craft list`, `craft tree`, `craft outdated`. Add sections for each new command with usage examples, following the existing pattern of `### craft add` (line 141) and `### craft remove` (line 159). Document `--verbose` and `--dry-run` flags in existing command sections or a new "Global Flags" section.
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] Lint clean: `task lint` (no Go changes, but verify)
+- [ ] Build succeeds: `task build`
+
+#### Manual Verification:
+- [ ] README accurately describes all new commands and flags
+- [ ] Docs.md is complete and accurate
+- [ ] Examples in README match actual command output format
+
+---
+
+## References
+- Spec: `.paw/work/cli-feature-bundle/Spec.md`
+- Research: `.paw/work/cli-feature-bundle/CodeResearch.md`
+- Work Shaping: `.paw/work/cli-feature-bundle/WorkShaping.md` (session artifact)

--- a/.paw/work/cli-feature-bundle/ImplementationPlan.md
+++ b/.paw/work/cli-feature-bundle/ImplementationPlan.md
@@ -89,7 +89,7 @@ Add `craft list` command that reads manifest + pinfile and prints a summary tabl
 - **`internal/cli/list.go`** (new file): New cobra command `listCmd` with `Use: "list"`, `Short: "List resolved dependencies"`, `RunE: runList`. Register `--detailed` bool flag. Implementation:
   1. Parse manifest via `manifest.ParseFile("craft.yaml")` — get `Dependencies` map (alias → URL) and package metadata
   2. Parse pinfile via `pinfile.ParseFile("craft.pin.yaml")` — get `Resolved` map
-  3. Handle missing pinfile → error with "run 'craft install' first" suggestion
+  3. Handle missing pinfile → extract a shared `loadManifestAndPinfile()` helper that both parses manifest + pinfile and returns a user-friendly error ("No craft.pin.yaml found. Run 'craft install' first.") when pinfile is missing. Place in a new `internal/cli/helpers.go` file. Phases 3 and 4 reuse this helper.
   4. Handle zero dependencies → print "No dependencies resolved." and return nil
   5. Join data: for each manifest dependency, find matching pinfile entry by URL key. Extract version via `resolve.ParseDepURL()` on the pinfile key
   6. Sort entries alphabetically by alias
@@ -130,7 +130,7 @@ Wire existing `ui.RenderTree()` to a standalone `craft tree` command. This is th
 - **`internal/cli/tree.go`** (new file): New cobra command `treeCmd` with `Use: "tree"`, `Short: "Print dependency tree"`, `RunE: runTree`. Implementation:
   1. Parse manifest — get package name, version, local skills
   2. Parse pinfile — get resolved dependencies
-  3. Handle missing pinfile → same error pattern as `craft list`
+  3. Handle missing pinfile → reuse `loadManifestAndPinfile()` helper from Phase 2
   4. Build `[]ui.DepNode` from pinfile data — follow exact pattern from `printDependencyTree()` at `install.go:211-237`
   5. Extract local skill names from manifest `Skills` paths — same logic as `install.go:218-223`
   6. Call `ui.RenderTree(cmd.OutOrStdout(), packageName, localSkills, deps)` — note: write to stdout (not stderr like install does) since this is the primary output, not a side effect
@@ -164,15 +164,16 @@ Add `craft outdated` command that checks each direct dependency against its remo
 
 - **`internal/cli/outdated.go`** (new file): New cobra command `outdatedCmd` with `Use: "outdated"`, `Short: "Show available dependency updates"`, `RunE: runOutdated`. Implementation:
   1. Parse manifest + pinfile (same pattern as list/tree)
-  2. Handle missing pinfile, zero dependencies (same error patterns)
-  3. Create fetcher via `newFetcher()` (reuse helper from `install.go:327-337` — may need to move to a shared location or keep as-is since it's package-level)
+  2. Handle missing pinfile, zero dependencies — reuse `loadManifestAndPinfile()` helper from Phase 2
+  3. Create fetcher via `newFetcher()` (reuse helper from `install.go:327-337` — it's package-level in the `cli` package so directly accessible)
   4. For each direct dependency (from manifest `Dependencies` map):
      a. Extract current version from pinfile key via `resolve.ParseDepURL()`
      b. Compute clone URL via `DepURL.HTTPSURL()` or `fetch.NormalizeCloneURL()`
      c. Call `fetcher.ListTags(cloneURL)` — wrap in error handling per-dependency
      d. Call `semver.FindLatest(tags)` — skip if no semver tags (warn)
-     e. Compare via `semver.Compare(current, latest)` — skip if up to date
-     f. Classify update type by comparing `semver.ParseParts()` results: if major differs → "major", else if minor differs → "minor", else → "patch"
+     e. Check whether pinned version tag exists in remote tag list — if absent, emit warning: "warning: pinned version vX.Y.Z not found in remote tags for <alias>". Still show current version with latest available.
+     f. Compare via `semver.Compare(current, latest)` — skip if up to date
+     g. Classify update type by comparing `semver.ParseParts()` results: if major differs → "major", else if minor differs → "minor", else → "patch"
   5. Print results sorted by alias: outdated deps show `alias  vCurrent → vLatest  (type)`, up-to-date deps show `alias  vCurrent  (up to date)`
   6. Track whether any dep is outdated — if so, return a sentinel error or use `os.Exit(1)` pattern
   7. Verbose output: log each fetch operation, version comparison result
@@ -191,7 +192,8 @@ Add `craft outdated` command that checks each direct dependency against its remo
   4. Zero dependencies → "No dependencies to check." message
   5. Fetch failure for one dep → error for that dep, continue checking others, exit 1
   6. Dependency with no semver tags → skip with warning
-  7. Major/minor/patch classification correctness
+  7. Dependency whose pinned version tag is absent from remote → warning + show current/latest
+  8. Major/minor/patch classification correctness
 
 ### Success Criteria
 

--- a/.paw/work/cli-feature-bundle/Spec.md
+++ b/.paw/work/cli-feature-bundle/Spec.md
@@ -1,0 +1,171 @@
+# Feature Specification: CLI Feature Bundle
+
+**Branch**: feature/cli-feature-bundle  |  **Created**: 2026-03-09  |  **Status**: Draft
+**Input Brief**: Add five missing CLI features — craft list, craft tree, craft outdated, --verbose flag, and --dry-run on install/update — to bring craft to package-manager parity.
+
+## Overview
+
+Craft currently lacks basic introspection and safety commands that developers expect from any dependency manager. Users cannot see what dependencies are resolved without manually reading `craft.pin.yaml`, cannot preview available updates before committing to them, and cannot visualize the dependency tree outside of an install operation. These gaps force users into manual file inspection and blind update workflows.
+
+This feature bundle adds five capabilities that close the ergonomic gap. Three new commands (`craft list`, `craft tree`, `craft outdated`) provide read-only visibility into the dependency state. A global `--verbose` flag gives developers diagnostic output for debugging resolution and authentication issues. A `--dry-run` flag on `install` and `update` lets users preview what would change before any files are modified.
+
+Together, these features make craft a more transparent, predictable, and CI-friendly tool. Users gain confidence in their dependency state, can make informed update decisions, and can safely validate operations in production environments before committing to changes.
+
+## Objectives
+
+- Enable developers to inspect their resolved dependency state without reading raw YAML files
+- Allow developers to discover available updates and assess their risk (major/minor/patch) before applying them
+- Provide a standalone dependency tree visualization for documentation and debugging
+- Give developers diagnostic output to troubleshoot resolution, fetching, and authentication issues
+- Let developers safely preview install and update operations without modifying any files
+
+## User Scenarios & Testing
+
+### User Story P1 – List Resolved Dependencies
+
+Narrative: A developer joins a project using craft and wants to quickly understand what dependencies are resolved and how many skills each provides, without opening configuration files.
+
+Independent Test: Run `craft list` in a project with resolved dependencies and see a summary table.
+
+Acceptance Scenarios:
+1. Given a project with `craft.pin.yaml` containing 3 resolved dependencies, When the user runs `craft list`, Then a table is printed showing each dependency's alias, version, and skill count, sorted alphabetically by alias.
+2. Given a project with `craft.pin.yaml`, When the user runs `craft list --detailed`, Then each dependency's alias, version, source URL, and individual skill names are shown.
+3. Given a project with no `craft.pin.yaml`, When the user runs `craft list`, Then an error message is printed directing the user to run `craft install` first, and the exit code is non-zero.
+4. Given a project with `craft.pin.yaml` containing zero resolved dependencies, When the user runs `craft list`, Then the message "No dependencies resolved." is printed and the exit code is 0.
+
+### User Story P1 – Preview Available Updates
+
+Narrative: A developer wants to check if any dependencies have newer versions available before deciding whether to run `craft update`. They need to see the update type (major/minor/patch) to assess risk.
+
+Independent Test: Run `craft outdated` and see which dependencies have updates available, with version comparison and risk classification.
+
+Acceptance Scenarios:
+1. Given a project with 2 resolved dependencies where one has a newer version available, When the user runs `craft outdated`, Then the outdated dependency shows current and latest versions with update type label, the up-to-date dependency shows "(up to date)", and the exit code is 1.
+2. Given a project where all dependencies are at their latest versions, When the user runs `craft outdated`, Then all dependencies show "(up to date)" and the exit code is 0.
+3. Given a project with no `craft.pin.yaml`, When the user runs `craft outdated`, Then an error message is printed directing the user to run `craft install` first.
+4. Given a dependency whose remote repository is unreachable, When the user runs `craft outdated`, Then an error is printed for that specific dependency, remaining dependencies are still checked, and the exit code is 1.
+5. Given a project with zero resolved dependencies, When the user runs `craft outdated`, Then the message "No dependencies to check." is printed and the exit code is 0.
+
+### User Story P2 – Visualize Dependency Tree
+
+Narrative: A developer wants to see the full dependency hierarchy — local skills and remote dependencies with their skills — as a tree diagram, without triggering an install.
+
+Independent Test: Run `craft tree` and see an ASCII tree showing the package, its local skills, and all resolved dependencies with their skills.
+
+Acceptance Scenarios:
+1. Given a project with local skills and resolved dependencies, When the user runs `craft tree`, Then an ASCII box-drawing tree is printed showing the package name, local skills, and each dependency with its skills.
+2. Given a project with no dependencies but local skills, When the user runs `craft tree`, Then the tree shows only the package name and local skills.
+3. Given a project with no `craft.pin.yaml`, When the user runs `craft tree`, Then an error message is printed directing the user to run `craft install` first.
+
+### User Story P2 – Verbose Diagnostic Output
+
+Narrative: A developer is debugging why `craft install` fails to resolve a dependency. They need to see detailed output — which repositories are being fetched, what versions are being compared, and whether authentication is succeeding.
+
+Independent Test: Run `craft install --verbose` and see detailed step-by-step output for each fetch, resolution, and installation operation.
+
+Acceptance Scenarios:
+1. Given a project with dependencies, When the user runs `craft install --verbose`, Then additional diagnostic output is printed showing fetch operations, version comparisons, cache interactions, and integrity checks.
+2. Given any craft command run without `--verbose`, When the command executes, Then output matches current behavior with no additional diagnostic messages.
+3. Given the `--verbose` flag (or `-v` shorthand), When used with any craft command, Then the flag is accepted without error.
+
+### User Story P2 – Dry-Run Preview for Install and Update
+
+Narrative: A developer working in a production environment wants to verify what `craft install` or `craft update` would do before allowing any files to be written. They need to see the full resolution result without any side effects.
+
+Independent Test: Run `craft install --dry-run` and see what would be resolved and installed, then verify no files were created or modified.
+
+Acceptance Scenarios:
+1. Given a project with dependencies, When the user runs `craft install --dry-run`, Then the resolution runs fully, a summary of what would be resolved and installed is printed, and neither `craft.pin.yaml` nor the target directory are modified.
+2. Given a project with dependencies, When the user runs `craft update --dry-run`, Then the resolution runs fully, a summary of what would change is printed, and neither `craft.pin.yaml` nor `craft.yaml` nor the target directory are modified.
+3. Given a project where resolution would fail (e.g., unresolvable dependency), When the user runs `craft install --dry-run`, Then the same error is shown as a normal install would produce.
+
+### Edge Cases
+
+- `craft list` and `craft tree` with a corrupted or unparseable `craft.pin.yaml`: standard YAML parse error with clear message.
+- `craft outdated` with a dependency that has no semver-compatible tags: skip with a warning message, continue checking other dependencies.
+- `craft outdated` with a dependency whose pinned version tag no longer exists on remote: show current version with a warning that the tag is missing from remote.
+- `--verbose` combined with `--dry-run`: both flags active; verbose shows resolution steps, dry-run prevents writes.
+- `craft list --detailed` with a dependency that has zero skills: show the dependency with "0 skills" or empty skill list.
+
+## Requirements
+
+### Functional Requirements
+
+- FR-001: `craft list` prints a table of resolved dependencies showing alias, version, and skill count, sorted alphabetically by alias. (Stories: P1-List)
+- FR-002: `craft list --detailed` prints extended information including source URL and individual skill names for each dependency. (Stories: P1-List)
+- FR-003: `craft outdated` compares each direct dependency's pinned version against the latest available semver tag from the remote repository. (Stories: P1-Outdated)
+- FR-004: `craft outdated` classifies each available update as major, minor, or patch based on which semver component changed. (Stories: P1-Outdated)
+- FR-005: `craft outdated` exits with code 1 when any dependency has an available update, and code 0 when all are up to date. (Stories: P1-Outdated)
+- FR-006: `craft tree` prints an ASCII dependency tree showing the package name, local skills, and all resolved dependencies with their skills. (Stories: P2-Tree)
+- FR-007: A global `--verbose` (`-v`) flag is available on all commands and, when set, causes additional diagnostic output to be printed. (Stories: P2-Verbose)
+- FR-008: `craft install --dry-run` runs full dependency resolution but does not write `craft.pin.yaml` or install files to the target directory. (Stories: P2-DryRun)
+- FR-009: `craft update --dry-run` runs full dependency resolution but does not modify `craft.yaml`, `craft.pin.yaml`, or install files to the target directory. (Stories: P2-DryRun)
+- FR-010: `craft list`, `craft tree`, and `craft outdated` produce a clear error message when no `craft.pin.yaml` exists, directing the user to run `craft install`. (Stories: P1-List, P1-Outdated, P2-Tree)
+- FR-011: `craft outdated` handles per-dependency fetch failures gracefully — printing an error for the failing dependency while continuing to check remaining dependencies. (Stories: P1-Outdated)
+- FR-012: `--dry-run` on install and update prints a summary of what would be resolved/changed. (Stories: P2-DryRun)
+
+### Cross-Cutting / Non-Functional
+
+- All new commands must follow existing cobra command registration patterns.
+- `--verbose` output goes to stderr so it does not interfere with parseable stdout output.
+- Read-only commands (`list`, `tree`, `outdated`) must not modify any files on disk.
+- All new commands and flags must have unit tests.
+
+## Success Criteria
+
+- SC-001: A user can determine the alias, version, and skill count of every resolved dependency by running a single command. (FR-001)
+- SC-002: A user can see the source URL and individual skill names for each resolved dependency using a flag. (FR-002)
+- SC-003: A user can identify which dependencies have newer versions available and the risk level of each update without applying any changes. (FR-003, FR-004)
+- SC-004: A CI script can detect whether any dependencies are outdated via exit code. (FR-005)
+- SC-005: A user can view the full dependency hierarchy as a tree without triggering installation. (FR-006)
+- SC-006: A user can enable verbose diagnostic output on any command to debug resolution or authentication issues. (FR-007)
+- SC-007: A user can preview the full result of an install or update operation with confidence that no files are modified. (FR-008, FR-009, FR-012)
+- SC-008: All three new commands produce a helpful error when the pinfile is missing. (FR-010)
+- SC-009: A single dependency failure during `craft outdated` does not prevent checking remaining dependencies. (FR-011)
+
+## Assumptions
+
+- The pinfile (`craft.pin.yaml`) is the authoritative source for "resolved" dependency state. There is no separate "installed on disk" verification.
+- Only direct dependencies (declared in `craft.yaml`) are checked by `craft outdated`. Transitive dependencies are managed by their parent packages.
+- Cache warming during `--dry-run` (fetching repository data to resolve) is acceptable since the cache is a side-effect-free optimization layer.
+- Dependencies without any semver-compatible tags are skipped by `craft outdated` with a warning rather than treated as errors.
+- The `--verbose` flag uses a 2-level model (normal/verbose). There is no `--quiet` flag — non-TTY environments already suppress progress output.
+
+## Scope
+
+In Scope:
+- `craft list` command with `--detailed` flag
+- `craft tree` command (standalone, read-only)
+- `craft outdated` command with semver classification and CI-friendly exit codes
+- `--verbose` / `-v` global persistent flag on root command
+- `--dry-run` flag on `install` and `update` commands
+- Unit tests for all new commands and flags
+- Error handling for missing pinfile across all new commands
+
+Out of Scope:
+- `--quiet` flag (non-TTY already suppresses progress)
+- `--dry-run` on `add` or `remove` commands
+- JSON or machine-readable output format
+- `craft search` or registry browsing
+- Colored output or ANSI formatting
+- `--format` flag for custom output templates
+- Verification of on-disk installation state
+
+## Dependencies
+
+- Existing `internal/pinfile` package for reading resolved dependency state
+- Existing `internal/manifest` package for reading declared dependencies and package info
+- Existing `internal/ui` package (tree rendering, progress output)
+- Existing `internal/fetch` and `internal/semver` packages for remote version checking
+- Cobra CLI framework for command and flag registration
+
+## Risks & Mitigations
+
+- **`--dry-run` control flow complexity**: Inserting an early-return into install/update could skip necessary setup or leave inconsistent state. Mitigation: Intercept at a clean boundary (after resolution, before writes) and test that resolution still works identically with and without the flag.
+- **`craft outdated` network latency**: Checking each dependency sequentially could be slow for projects with many dependencies. Mitigation: Accept sequential for v1; note parallel fetching as a future optimization.
+- **`--verbose` output noise**: Too much diagnostic output reduces its usefulness. Mitigation: Limit verbose output to key operations (fetch, resolve, verify) rather than every internal step.
+
+## References
+
+- WorkShaping: `.paw/work/cli-feature-bundle/WorkShaping.md` (session artifact)
+- Codebase audit: `codeFindings.md` section 6 (feature source)

--- a/.paw/work/cli-feature-bundle/WorkflowContext.md
+++ b/.paw/work/cli-feature-bundle/WorkflowContext.md
@@ -1,0 +1,30 @@
+# WorkflowContext
+
+Work Title: CLI Feature Bundle
+Work ID: cli-feature-bundle
+Base Branch: main
+Target Branch: feature/cli-feature-bundle
+Workflow Mode: full
+Review Strategy: local
+Review Policy: final-pr-only
+Session Policy: continuous
+Final Agent Review: enabled
+Final Review Mode: society-of-thought
+Final Review Interactive: smart
+Final Review Models: none
+Final Review Specialists: all
+Final Review Interaction Mode: parallel
+Final Review Specialist Models: none
+Plan Generation Mode: single-model
+Plan Generation Models: none
+Planning Docs Review: enabled
+Planning Review Mode: single-model
+Planning Review Interactive: smart
+Planning Review Models: none
+Custom Workflow Instructions: none
+Initial Prompt: Implement 5 CLI features: craft list, craft tree, craft outdated, --verbose global flag, --dry-run on install/update. See WorkShaping.md for full design decisions.
+Issue URL: none
+Remote: origin
+Artifact Lifecycle: commit-and-persist
+Artifact Paths: auto-derived
+Additional Inputs: none

--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ go build -o craft ./cmd/craft
 | `craft update [alias]` | Update dependencies to latest semver tags |
 | `craft add [alias] <url>` | Add a dependency (verify, then update manifest) |
 | `craft remove <alias>` | Remove a dependency and clean up orphaned skills |
+| `craft list` | List resolved dependencies with versions and skill counts |
+| `craft tree` | Print the dependency tree |
+| `craft outdated` | Show available dependency updates |
 | `craft validate` | Run all validation checks (schema, paths, frontmatter, deps, collisions) |
 | `craft cache clean` | Remove all cached repositories from `~/.craft/cache/` |
 | `craft version` | Print version and exit |
@@ -176,6 +179,67 @@ Remove all cached git repositories from `~/.craft/cache/`.
 $ craft cache clean
 Removed cache directory: /home/user/.craft/cache
 ```
+
+### `craft list`
+
+Show all resolved dependencies from `craft.pin.yaml`.
+
+```bash
+$ craft list
+company-standards  v2.1.0  (2 skills)
+utility-skills     v1.0.0  (1 skill)
+
+# Show extended information including URLs and skill names
+$ craft list --detailed
+company-standards  v2.1.0  github.com/org/standards
+  skills: api-conventions, error-formats
+
+utility-skills     v1.0.0  github.com/org/utils
+  skills: git-helper
+```
+
+### `craft tree`
+
+Print the dependency tree showing local skills and all resolved dependencies.
+
+```bash
+$ craft tree
+my-package@1.0.0
+├── Local skills
+│   ├── skill-a
+│   └── skill-b
+├── company-standards (github.com/org/standards@v2.1.0)
+│   ├── api-conventions
+│   └── error-formats
+└── utility-skills (github.com/org/utils@v1.0.0)
+    └── git-helper
+```
+
+### `craft outdated`
+
+Check each direct dependency for newer versions. Exits with code 1 when updates are available (useful for CI).
+
+```bash
+$ craft outdated
+company-standards  v2.1.0 → v2.2.0  (minor)
+utility-skills     v1.0.0            (up to date)
+
+$ echo $?
+1
+```
+
+### Global Flags
+
+| Flag | Description |
+|------|-------------|
+| `--verbose`, `-v` | Enable verbose diagnostic output (shows fetches, version comparisons, cache operations) |
+
+### Operation Flags
+
+| Flag | Available On | Description |
+|------|-------------|-------------|
+| `--dry-run` | `install`, `update` | Show what would happen without making any changes |
+| `--target <path>` | `install`, `update`, `add`, `remove` | Override agent auto-detection with a custom install path |
 
 ## Manifest Reference (`craft.yaml`)
 

--- a/cmd/craft/main.go
+++ b/cmd/craft/main.go
@@ -8,6 +8,6 @@ import (
 
 func main() {
 	if err := cli.Execute(); err != nil {
-		os.Exit(1)
+		os.Exit(cli.ExitCode(err))
 	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -38,7 +38,7 @@ func TestRootHelp(t *testing.T) {
 	}
 
 	output := buf.String()
-	for _, sub := range []string{"init", "validate", "version"} {
+	for _, sub := range []string{"init", "validate", "version", "list", "tree", "outdated"} {
 		if !strings.Contains(output, sub) {
 			t.Errorf("help output should list %q subcommand, got %q", sub, output)
 		}

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/erdemtuna/craft/internal/manifest"
 	"github.com/erdemtuna/craft/internal/pinfile"
+	"github.com/erdemtuna/craft/internal/resolve"
+	"github.com/spf13/cobra"
 )
 
 // requireManifestAndPinfile parses both craft.yaml and craft.pin.yaml from the
@@ -36,4 +39,28 @@ func requireManifestAndPinfile() (*manifest.Manifest, *pinfile.Pinfile, error) {
 	}
 
 	return m, pf, nil
+}
+
+// printDryRunSummary prints what would be resolved without making changes.
+// Used by both install --dry-run and update --dry-run.
+func printDryRunSummary(cmd *cobra.Command, result *resolve.ResolveResult, prefix string) {
+	cmd.Printf("Would resolve %d dependency(ies):\n", len(result.Resolved))
+	for _, dep := range result.Resolved {
+		skillWord := "skills"
+		if len(dep.Skills) == 1 {
+			skillWord = "skill"
+		}
+		parsed, err := resolve.ParseDepURL(dep.URL)
+		if err != nil {
+			cmd.Printf("  %s %s  (%d %s)\n", prefix, sanitize(dep.Alias), len(dep.Skills), skillWord)
+			continue
+		}
+		if len(dep.Skills) > 0 {
+			cmd.Printf("  %s %s  %s  (%d %s: %s)\n", prefix, sanitize(dep.Alias), parsed.GitTag(),
+				len(dep.Skills), skillWord, sanitize(strings.Join(dep.Skills, ", ")))
+		} else {
+			cmd.Printf("  %s %s  %s  (0 skills)\n", prefix, sanitize(dep.Alias), parsed.GitTag())
+		}
+	}
+	cmd.Println("\nNo changes made.")
 }

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -10,10 +10,10 @@ import (
 	"github.com/erdemtuna/craft/internal/pinfile"
 )
 
-// loadManifestAndPinfile parses both craft.yaml and craft.pin.yaml from the
+// requireManifestAndPinfile parses both craft.yaml and craft.pin.yaml from the
 // current working directory. It returns a user-friendly error if either file
-// is missing.
-func loadManifestAndPinfile() (*manifest.Manifest, *pinfile.Pinfile, error) {
+// is missing — callers should not proceed without both files.
+func requireManifestAndPinfile() (*manifest.Manifest, *pinfile.Pinfile, error) {
 	root, err := os.Getwd()
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting working directory: %w", err)

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/erdemtuna/craft/internal/manifest"
+	"github.com/erdemtuna/craft/internal/pinfile"
+)
+
+// loadManifestAndPinfile parses both craft.yaml and craft.pin.yaml from the
+// current working directory. It returns a user-friendly error if either file
+// is missing.
+func loadManifestAndPinfile() (*manifest.Manifest, *pinfile.Pinfile, error) {
+	root, err := os.Getwd()
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting working directory: %w", err)
+	}
+
+	m, err := manifest.ParseFile(filepath.Join(root, "craft.yaml"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil, fmt.Errorf("craft.yaml not found\n  hint: run `craft init` to create one")
+		}
+		return nil, nil, fmt.Errorf("reading craft.yaml: %w", err)
+	}
+
+	pf, err := pinfile.ParseFile(filepath.Join(root, "craft.pin.yaml"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil, fmt.Errorf("craft.pin.yaml not found\n  hint: run `craft install` to resolve and pin dependencies")
+		}
+		return nil, nil, fmt.Errorf("reading craft.pin.yaml: %w", err)
+	}
+
+	return m, pf, nil
+}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -345,25 +345,3 @@ func newFetcher() (fetch.GitFetcher, error) {
 	return fetch.NewGoGitFetcher(cache), nil
 }
 
-// printDryRunSummary prints what would be resolved without making changes.
-func printDryRunSummary(cmd *cobra.Command, result *resolve.ResolveResult, prefix string) {
-	cmd.Printf("Would resolve %d dependency(ies):\n", len(result.Resolved))
-	for _, dep := range result.Resolved {
-		skillWord := "skills"
-		if len(dep.Skills) == 1 {
-			skillWord = "skill"
-		}
-		parsed, err := resolve.ParseDepURL(dep.URL)
-		if err != nil {
-			cmd.Printf("  %s %s  (%d %s)\n", prefix, dep.Alias, len(dep.Skills), skillWord)
-			continue
-		}
-		if len(dep.Skills) > 0 {
-			cmd.Printf("  %s %s  %s  (%d %s: %s)\n", prefix, dep.Alias, parsed.GitTag(),
-				len(dep.Skills), skillWord, strings.Join(dep.Skills, ", "))
-		} else {
-			cmd.Printf("  %s %s  %s  (0 skills)\n", prefix, dep.Alias, parsed.GitTag())
-		}
-	}
-	cmd.Println("\nNo changes made.")
-}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -358,8 +358,12 @@ func printDryRunSummary(cmd *cobra.Command, result *resolve.ResolveResult, prefi
 			cmd.Printf("  %s %s  (%d %s)\n", prefix, dep.Alias, len(dep.Skills), skillWord)
 			continue
 		}
-		cmd.Printf("  %s %s  %s  (%d %s: %s)\n", prefix, dep.Alias, parsed.GitTag(),
-			len(dep.Skills), skillWord, strings.Join(dep.Skills, ", "))
+		if len(dep.Skills) > 0 {
+			cmd.Printf("  %s %s  %s  (%d %s: %s)\n", prefix, dep.Alias, parsed.GitTag(),
+				len(dep.Skills), skillWord, strings.Join(dep.Skills, ", "))
+		} else {
+			cmd.Printf("  %s %s  %s  (0 skills)\n", prefix, dep.Alias, parsed.GitTag())
+		}
 	}
 	cmd.Println("\nNo changes made.")
 }

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -344,4 +344,3 @@ func newFetcher() (fetch.GitFetcher, error) {
 	}
 	return fetch.NewGoGitFetcher(cache), nil
 }
-

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -22,6 +22,7 @@ import (
 )
 
 var installTarget string
+var installDryRun bool
 
 var installCmd = &cobra.Command{
 	Use:   "install",
@@ -33,6 +34,7 @@ var installCmd = &cobra.Command{
 
 func init() {
 	installCmd.Flags().StringVar(&installTarget, "target", "", "Override agent auto-detection with a custom install path")
+	installCmd.Flags().BoolVar(&installDryRun, "dry-run", false, "Show what would be resolved and installed without making changes")
 }
 
 func runInstall(cmd *cobra.Command, args []string) error {
@@ -81,6 +83,13 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("resolution failed: %w", err)
 	}
 	progress.Update(fmt.Sprintf("Resolved %d dependency(ies)", len(result.Resolved)))
+
+	// Dry-run: show what would happen and exit
+	if installDryRun {
+		progress.Done("Dry-run complete")
+		printDryRunSummary(cmd, result, "+")
+		return nil
+	}
 
 	// Write pinfile atomically
 	if err := writePinfileAtomic(pfPath, result.Pinfile); err != nil {
@@ -334,4 +343,23 @@ func newFetcher() (fetch.GitFetcher, error) {
 		return nil, err
 	}
 	return fetch.NewGoGitFetcher(cache), nil
+}
+
+// printDryRunSummary prints what would be resolved without making changes.
+func printDryRunSummary(cmd *cobra.Command, result *resolve.ResolveResult, prefix string) {
+	cmd.Printf("Would resolve %d dependency(ies):\n", len(result.Resolved))
+	for _, dep := range result.Resolved {
+		skillWord := "skills"
+		if len(dep.Skills) == 1 {
+			skillWord = "skill"
+		}
+		parsed, err := resolve.ParseDepURL(dep.URL)
+		if err != nil {
+			cmd.Printf("  %s %s  (%d %s)\n", prefix, dep.Alias, len(dep.Skills), skillWord)
+			continue
+		}
+		cmd.Printf("  %s %s  %s  (%d %s: %s)\n", prefix, dep.Alias, parsed.GitTag(),
+			len(dep.Skills), skillWord, strings.Join(dep.Skills, ", "))
+	}
+	cmd.Println("\nNo changes made.")
 }

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/erdemtuna/craft/internal/resolve"
+	"github.com/spf13/cobra"
+)
+
+var listDetailed bool
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List resolved dependencies",
+	Long:  "Show all dependencies resolved in craft.pin.yaml with their versions and skill counts.",
+	Args:  cobra.NoArgs,
+	RunE:  runList,
+}
+
+func init() {
+	listCmd.Flags().BoolVar(&listDetailed, "detailed", false, "Show extended dependency information including URLs and skill names")
+}
+
+func runList(cmd *cobra.Command, args []string) error {
+	m, pf, err := loadManifestAndPinfile()
+	if err != nil {
+		return err
+	}
+
+	verboseLog(cmd, "Loaded manifest: %s@%s", m.Name, m.Version)
+	verboseLog(cmd, "Loaded pinfile with %d resolved entries", len(pf.Resolved))
+
+	if len(pf.Resolved) == 0 {
+		cmd.Println("No dependencies resolved.")
+		return nil
+	}
+
+	// Build alias-to-URL lookup from manifest
+	urlToAlias := make(map[string]string)
+	for alias, depURL := range m.Dependencies {
+		parsed, err := resolve.ParseDepURL(depURL)
+		if err != nil {
+			continue
+		}
+		urlToAlias[parsed.PackageIdentity()] = alias
+	}
+
+	type depInfo struct {
+		alias   string
+		version string
+		url     string
+		skills  []string
+	}
+
+	var deps []depInfo
+	for key, entry := range pf.Resolved {
+		parsed, err := resolve.ParseDepURL(key)
+		if err != nil {
+			verboseLog(cmd, "Skipping unparseable pinfile key: %s", key)
+			continue
+		}
+
+		alias := urlToAlias[parsed.PackageIdentity()]
+		if alias == "" {
+			alias = parsed.Repo
+		}
+
+		deps = append(deps, depInfo{
+			alias:   alias,
+			version: "v" + parsed.Version,
+			url:     parsed.PackageIdentity(),
+			skills:  entry.Skills,
+		})
+	}
+
+	sort.Slice(deps, func(i, j int) bool {
+		return deps[i].alias < deps[j].alias
+	})
+
+	if listDetailed {
+		for _, d := range deps {
+			cmd.Printf("%s  %s  %s\n", d.alias, d.version, d.url)
+			if len(d.skills) > 0 {
+				cmd.Printf("  skills: %s\n", strings.Join(d.skills, ", "))
+			} else {
+				cmd.Printf("  skills: (none)\n")
+			}
+			cmd.Println()
+		}
+	} else {
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 2, 2, ' ', 0)
+		for _, d := range deps {
+			skillWord := "skills"
+			if len(d.skills) == 1 {
+				skillWord = "skill"
+			}
+			fmt.Fprintf(w, "%s\t%s\t(%d %s)\n", d.alias, d.version, len(d.skills), skillWord)
+		}
+		w.Flush()
+	}
+
+	return nil
+}

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -97,9 +97,9 @@ func runList(cmd *cobra.Command, args []string) error {
 			if len(d.skills) == 1 {
 				skillWord = "skill"
 			}
-			fmt.Fprintf(w, "%s\t%s\t(%d %s)\n", sanitize(d.alias), d.version, len(d.skills), skillWord)
+			_, _ = fmt.Fprintf(w, "%s\t%s\t(%d %s)\n", sanitize(d.alias), d.version, len(d.skills), skillWord)
 		}
-		w.Flush()
+		_ = w.Flush()
 	}
 
 	return nil

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -82,9 +82,9 @@ func runList(cmd *cobra.Command, args []string) error {
 
 	if listDetailed {
 		for _, d := range deps {
-			cmd.Printf("%s  %s  %s\n", d.alias, d.version, d.url)
+			cmd.Printf("%s  %s  %s\n", sanitize(d.alias), d.version, sanitize(d.url))
 			if len(d.skills) > 0 {
-				cmd.Printf("  skills: %s\n", strings.Join(d.skills, ", "))
+				cmd.Printf("  skills: %s\n", sanitize(strings.Join(d.skills, ", ")))
 			} else {
 				cmd.Printf("  skills: (none)\n")
 			}
@@ -97,7 +97,7 @@ func runList(cmd *cobra.Command, args []string) error {
 			if len(d.skills) == 1 {
 				skillWord = "skill"
 			}
-			fmt.Fprintf(w, "%s\t%s\t(%d %s)\n", d.alias, d.version, len(d.skills), skillWord)
+			fmt.Fprintf(w, "%s\t%s\t(%d %s)\n", sanitize(d.alias), d.version, len(d.skills), skillWord)
 		}
 		w.Flush()
 	}

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -25,7 +25,7 @@ func init() {
 }
 
 func runList(cmd *cobra.Command, args []string) error {
-	m, pf, err := loadManifestAndPinfile()
+	m, pf, err := requireManifestAndPinfile()
 	if err != nil {
 		return err
 	}

--- a/internal/cli/list_test.go
+++ b/internal/cli/list_test.go
@@ -1,0 +1,211 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestListWithDependencies(t *testing.T) {
+	dir := t.TempDir()
+	testChdir(t, dir)
+
+	testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
+name: test-pkg
+version: 1.0.0
+skills:
+  - skills/local
+dependencies:
+  my-dep: github.com/org/repo@v1.2.0
+`))
+
+	testWriteFile(t, "craft.pin.yaml", []byte(`pin_version: 1
+resolved:
+  github.com/org/repo@v1.2.0:
+    commit: abc123
+    integrity: sha256-test
+    skills:
+      - skill-a
+      - skill-b
+`))
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"list"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("list command failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "my-dep") {
+		t.Errorf("output should contain alias 'my-dep', got %q", output)
+	}
+	if !strings.Contains(output, "v1.2.0") {
+		t.Errorf("output should contain version 'v1.2.0', got %q", output)
+	}
+	if !strings.Contains(output, "2 skills") {
+		t.Errorf("output should contain '2 skills', got %q", output)
+	}
+}
+
+func TestListDetailed(t *testing.T) {
+	dir := t.TempDir()
+	testChdir(t, dir)
+
+	testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
+name: test-pkg
+version: 1.0.0
+skills:
+  - skills/local
+dependencies:
+  my-dep: github.com/org/repo@v1.2.0
+`))
+
+	testWriteFile(t, "craft.pin.yaml", []byte(`pin_version: 1
+resolved:
+  github.com/org/repo@v1.2.0:
+    commit: abc123
+    integrity: sha256-test
+    skills:
+      - skill-a
+      - skill-b
+`))
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"list", "--detailed"})
+	t.Cleanup(func() { listDetailed = false })
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("list --detailed failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "github.com/org/repo") {
+		t.Errorf("detailed output should contain URL, got %q", output)
+	}
+	if !strings.Contains(output, "skill-a") {
+		t.Errorf("detailed output should contain skill names, got %q", output)
+	}
+}
+
+func TestListNoPinfile(t *testing.T) {
+	dir := t.TempDir()
+	testChdir(t, dir)
+
+	testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
+name: test-pkg
+version: 1.0.0
+skills:
+  - skills/local
+`))
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"list"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("list should error when no pinfile exists")
+	}
+	if !strings.Contains(err.Error(), "craft.pin.yaml not found") {
+		t.Errorf("error should mention missing pinfile, got %q", err.Error())
+	}
+}
+
+func TestListZeroDependencies(t *testing.T) {
+	dir := t.TempDir()
+	testChdir(t, dir)
+
+	testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
+name: test-pkg
+version: 1.0.0
+skills:
+  - skills/local
+`))
+
+	testWriteFile(t, "craft.pin.yaml", []byte(`pin_version: 1
+resolved: {}
+`))
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"list"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("list with empty deps should not error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "No dependencies resolved") {
+		t.Errorf("output should say no dependencies, got %q", output)
+	}
+}
+
+func TestListSingleSkill(t *testing.T) {
+	dir := t.TempDir()
+	testChdir(t, dir)
+
+	testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
+name: test-pkg
+version: 1.0.0
+skills:
+  - skills/local
+dependencies:
+  my-dep: github.com/org/repo@v1.0.0
+`))
+
+	testWriteFile(t, "craft.pin.yaml", []byte(`pin_version: 1
+resolved:
+  github.com/org/repo@v1.0.0:
+    commit: abc123
+    integrity: sha256-test
+    skills:
+      - only-skill
+`))
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"list"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "1 skill)") {
+		t.Errorf("output should show '1 skill' (singular), got %q", output)
+	}
+}
+
+func TestListNoManifest(t *testing.T) {
+	dir := t.TempDir()
+	testChdir(t, dir)
+
+	// No craft.yaml at all
+	_ = os.Remove("craft.yaml")
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"list"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("list should error when no manifest exists")
+	}
+	if !strings.Contains(err.Error(), "craft.yaml not found") {
+		t.Errorf("error should mention missing manifest, got %q", err.Error())
+	}
+}

--- a/internal/cli/list_test.go
+++ b/internal/cli/list_test.go
@@ -209,3 +209,98 @@ func TestListNoManifest(t *testing.T) {
 		t.Errorf("error should mention missing manifest, got %q", err.Error())
 	}
 }
+
+func TestListSortOrder(t *testing.T) {
+	dir := t.TempDir()
+	testChdir(t, dir)
+
+	testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
+name: test-pkg
+version: 1.0.0
+skills:
+  - skills/local
+dependencies:
+  zebra: github.com/org/zebra@v1.0.0
+  alpha: github.com/org/alpha@v2.0.0
+  middle: github.com/org/middle@v1.5.0
+`))
+
+	testWriteFile(t, "craft.pin.yaml", []byte(`pin_version: 1
+resolved:
+  github.com/org/zebra@v1.0.0:
+    commit: abc
+    integrity: sha256-test
+    skills:
+      - z-skill
+  github.com/org/alpha@v2.0.0:
+    commit: def
+    integrity: sha256-test
+    skills:
+      - a-skill
+  github.com/org/middle@v1.5.0:
+    commit: ghi
+    integrity: sha256-test
+    skills:
+      - m-skill
+`))
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"list"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+
+	output := buf.String()
+	alphaIdx := strings.Index(output, "alpha")
+	middleIdx := strings.Index(output, "middle")
+	zebraIdx := strings.Index(output, "zebra")
+
+	if alphaIdx == -1 || middleIdx == -1 || zebraIdx == -1 {
+		t.Fatalf("output missing deps, got %q", output)
+	}
+	if !(alphaIdx < middleIdx && middleIdx < zebraIdx) {
+		t.Errorf("deps should be sorted alphabetically (alpha < middle < zebra), got %q", output)
+	}
+}
+
+func TestListDetailedZeroSkills(t *testing.T) {
+	dir := t.TempDir()
+	testChdir(t, dir)
+
+	testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
+name: test-pkg
+version: 1.0.0
+skills:
+  - skills/local
+dependencies:
+  my-dep: github.com/org/repo@v1.0.0
+`))
+
+	testWriteFile(t, "craft.pin.yaml", []byte(`pin_version: 1
+resolved:
+  github.com/org/repo@v1.0.0:
+    commit: abc123
+    integrity: sha256-test
+    skills: []
+`))
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"list", "--detailed"})
+	t.Cleanup(func() { listDetailed = false })
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("list --detailed failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "(none)") {
+		t.Errorf("detailed output should show '(none)' for zero skills, got %q", output)
+	}
+}

--- a/internal/cli/list_test.go
+++ b/internal/cli/list_test.go
@@ -262,7 +262,7 @@ resolved:
 	if alphaIdx == -1 || middleIdx == -1 || zebraIdx == -1 {
 		t.Fatalf("output missing deps, got %q", output)
 	}
-	if !(alphaIdx < middleIdx && middleIdx < zebraIdx) {
+	if alphaIdx >= middleIdx || middleIdx >= zebraIdx {
 		t.Errorf("deps should be sorted alphabetically (alpha < middle < zebra), got %q", output)
 	}
 }

--- a/internal/cli/outdated.go
+++ b/internal/cli/outdated.go
@@ -55,6 +55,7 @@ func runOutdated(cmd *cobra.Command, args []string) error {
 		updateType string
 		err        error
 		warning    string
+		skipped    bool
 	}
 
 	var results []depStatus
@@ -95,6 +96,7 @@ func runOutdated(cmd *cobra.Command, args []string) error {
 				alias:   alias,
 				current: currentVersion,
 				warning: "no semver tags found",
+				skipped: true,
 			})
 			continue
 		}
@@ -151,6 +153,9 @@ func runOutdated(cmd *cobra.Command, args []string) error {
 		}
 		if r.warning != "" {
 			fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s: %s\n", r.alias, r.warning)
+		}
+		if r.skipped {
+			continue
 		}
 		if r.latest != "" {
 			fmt.Fprintf(w, "%s\tv%s → v%s\t(%s)\n", r.alias, r.current, r.latest, r.updateType)

--- a/internal/cli/outdated.go
+++ b/internal/cli/outdated.go
@@ -157,24 +157,24 @@ func runOutdated(cmd *cobra.Command, args []string) error {
 
 	for _, r := range results {
 		if r.err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "error: %s: %v\n", sanitize(r.alias), r.err)
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "error: %s: %v\n", sanitize(r.alias), r.err)
 			hasErrors = true
 			continue
 		}
 		if r.warning != "" {
-			fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s: %s\n", sanitize(r.alias), r.warning)
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s: %s\n", sanitize(r.alias), r.warning)
 		}
 		if r.skipped {
 			continue
 		}
 		if r.latest != "" {
-			fmt.Fprintf(w, "%s\tv%s → v%s\t(%s)\n", sanitize(r.alias), r.current, r.latest, r.updateType)
+			_, _ = fmt.Fprintf(w, "%s\tv%s → v%s\t(%s)\n", sanitize(r.alias), r.current, r.latest, r.updateType)
 			hasUpdates = true
 		} else {
-			fmt.Fprintf(w, "%s\tv%s\t(up to date)\n", sanitize(r.alias), r.current)
+			_, _ = fmt.Fprintf(w, "%s\tv%s\t(up to date)\n", sanitize(r.alias), r.current)
 		}
 	}
-	w.Flush()
+	_ = w.Flush()
 
 	if hasUpdates || hasErrors {
 		return &silentExitError{code: 1}

--- a/internal/cli/outdated.go
+++ b/internal/cli/outdated.go
@@ -1,0 +1,181 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/erdemtuna/craft/internal/fetch"
+	"github.com/erdemtuna/craft/internal/resolve"
+	"github.com/erdemtuna/craft/internal/semver"
+	"github.com/spf13/cobra"
+)
+
+var outdatedCmd = &cobra.Command{
+	Use:   "outdated",
+	Short: "Show available dependency updates",
+	Long:  "Check each direct dependency for newer versions and classify updates as major, minor, or patch.",
+	Args:  cobra.NoArgs,
+	RunE:  runOutdated,
+}
+
+func runOutdated(cmd *cobra.Command, args []string) error {
+	m, pf, err := loadManifestAndPinfile()
+	if err != nil {
+		return err
+	}
+
+	if len(m.Dependencies) == 0 {
+		cmd.Println("No dependencies to check.")
+		return nil
+	}
+
+	verboseLog(cmd, "Checking %d direct dependencies for updates...", len(m.Dependencies))
+
+	fetcher, err := newFetcher()
+	if err != nil {
+		return err
+	}
+
+	// Build pinfile identity-to-key lookup for finding current version
+	pinKeyByIdentity := make(map[string]string)
+	for key := range pf.Resolved {
+		parsed, err := resolve.ParseDepURL(key)
+		if err != nil {
+			continue
+		}
+		pinKeyByIdentity[parsed.PackageIdentity()] = key
+	}
+
+	type depStatus struct {
+		alias      string
+		current    string
+		latest     string
+		updateType string
+		err        error
+		warning    string
+	}
+
+	var results []depStatus
+
+	for alias, depURL := range m.Dependencies {
+		parsed, err := resolve.ParseDepURL(depURL)
+		if err != nil {
+			results = append(results, depStatus{alias: alias, err: fmt.Errorf("invalid URL: %w", err)})
+			continue
+		}
+
+		// Find current version from pinfile
+		currentVersion := parsed.Version
+		if pinKey, ok := pinKeyByIdentity[parsed.PackageIdentity()]; ok {
+			if pinParsed, err := resolve.ParseDepURL(pinKey); err == nil {
+				currentVersion = pinParsed.Version
+			}
+		}
+
+		cloneURL := fetch.NormalizeCloneURL(parsed.PackageIdentity())
+		verboseLog(cmd, "Fetching tags from %s...", cloneURL)
+
+		tags, err := fetcher.ListTags(cloneURL)
+		if err != nil {
+			results = append(results, depStatus{
+				alias:   alias,
+				current: currentVersion,
+				err:     fmt.Errorf("failed to list tags: %w", err),
+			})
+			continue
+		}
+
+		verboseLog(cmd, "Found %d tags for %s", len(tags), alias)
+
+		latest := semver.FindLatest(tags)
+		if latest == "" {
+			results = append(results, depStatus{
+				alias:   alias,
+				current: currentVersion,
+				warning: "no semver tags found",
+			})
+			continue
+		}
+
+		latestVersion := strings.TrimPrefix(latest, "v")
+
+		// Check if pinned version tag exists in remote tags
+		pinnedTag := "v" + currentVersion
+		tagExists := false
+		for _, t := range tags {
+			if t == pinnedTag {
+				tagExists = true
+				break
+			}
+		}
+
+		var warning string
+		if !tagExists {
+			warning = fmt.Sprintf("pinned version %s not found in remote tags", pinnedTag)
+		}
+
+		if semver.Compare(currentVersion, latestVersion) < 0 {
+			updateType := classifyUpdate(currentVersion, latestVersion)
+			results = append(results, depStatus{
+				alias:      alias,
+				current:    currentVersion,
+				latest:     latestVersion,
+				updateType: updateType,
+				warning:    warning,
+			})
+		} else {
+			results = append(results, depStatus{
+				alias:   alias,
+				current: currentVersion,
+				warning: warning,
+			})
+		}
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].alias < results[j].alias
+	})
+
+	// Print results
+	hasUpdates := false
+	hasErrors := false
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 2, 2, ' ', 0)
+
+	for _, r := range results {
+		if r.err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "error: %s: %v\n", r.alias, r.err)
+			hasErrors = true
+			continue
+		}
+		if r.warning != "" {
+			fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s: %s\n", r.alias, r.warning)
+		}
+		if r.latest != "" {
+			fmt.Fprintf(w, "%s\tv%s → v%s\t(%s)\n", r.alias, r.current, r.latest, r.updateType)
+			hasUpdates = true
+		} else {
+			fmt.Fprintf(w, "%s\tv%s\t(up to date)\n", r.alias, r.current)
+		}
+	}
+	w.Flush()
+
+	if hasUpdates || hasErrors {
+		return &silentExitError{code: 1}
+	}
+	return nil
+}
+
+// classifyUpdate determines if an update is major, minor, or patch.
+func classifyUpdate(current, latest string) string {
+	c := semver.ParseParts(current)
+	l := semver.ParseParts(latest)
+	if l[0] != c[0] {
+		return "major"
+	}
+	if l[1] != c[1] {
+		return "minor"
+	}
+	return "patch"
+}

--- a/internal/cli/outdated.go
+++ b/internal/cli/outdated.go
@@ -21,7 +21,7 @@ var outdatedCmd = &cobra.Command{
 }
 
 func runOutdated(cmd *cobra.Command, args []string) error {
-	m, pf, err := loadManifestAndPinfile()
+	m, pf, err := requireManifestAndPinfile()
 	if err != nil {
 		return err
 	}

--- a/internal/cli/outdated.go
+++ b/internal/cli/outdated.go
@@ -60,7 +60,15 @@ func runOutdated(cmd *cobra.Command, args []string) error {
 
 	var results []depStatus
 
-	for alias, depURL := range m.Dependencies {
+	// Sort dependency aliases for deterministic iteration order and verbose output
+	aliases := make([]string, 0, len(m.Dependencies))
+	for alias := range m.Dependencies {
+		aliases = append(aliases, alias)
+	}
+	sort.Strings(aliases)
+
+	for _, alias := range aliases {
+		depURL := m.Dependencies[alias]
 		parsed, err := resolve.ParseDepURL(depURL)
 		if err != nil {
 			results = append(results, depStatus{alias: alias, err: fmt.Errorf("invalid URL: %w", err)})
@@ -73,6 +81,8 @@ func runOutdated(cmd *cobra.Command, args []string) error {
 			if pinParsed, err := resolve.ParseDepURL(pinKey); err == nil {
 				currentVersion = pinParsed.Version
 			}
+		} else {
+			verboseLog(cmd, "No pinfile entry for %s, using manifest version v%s", alias, currentVersion)
 		}
 
 		cloneURL := fetch.NormalizeCloneURL(parsed.PackageIdentity())
@@ -147,21 +157,21 @@ func runOutdated(cmd *cobra.Command, args []string) error {
 
 	for _, r := range results {
 		if r.err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "error: %s: %v\n", r.alias, r.err)
+			fmt.Fprintf(cmd.ErrOrStderr(), "error: %s: %v\n", sanitize(r.alias), r.err)
 			hasErrors = true
 			continue
 		}
 		if r.warning != "" {
-			fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s: %s\n", r.alias, r.warning)
+			fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s: %s\n", sanitize(r.alias), r.warning)
 		}
 		if r.skipped {
 			continue
 		}
 		if r.latest != "" {
-			fmt.Fprintf(w, "%s\tv%s → v%s\t(%s)\n", r.alias, r.current, r.latest, r.updateType)
+			fmt.Fprintf(w, "%s\tv%s → v%s\t(%s)\n", sanitize(r.alias), r.current, r.latest, r.updateType)
 			hasUpdates = true
 		} else {
-			fmt.Fprintf(w, "%s\tv%s\t(up to date)\n", r.alias, r.current)
+			fmt.Fprintf(w, "%s\tv%s\t(up to date)\n", sanitize(r.alias), r.current)
 		}
 	}
 	w.Flush()

--- a/internal/cli/outdated_test.go
+++ b/internal/cli/outdated_test.go
@@ -1,81 +1,81 @@
 package cli
 
 import (
-"bytes"
-"strings"
-"testing"
+	"bytes"
+	"strings"
+	"testing"
 
-"github.com/erdemtuna/craft/internal/resolve"
+	"github.com/erdemtuna/craft/internal/resolve"
 )
 
 func TestClassifyUpdate(t *testing.T) {
-tests := []struct {
-current string
-latest  string
-want    string
-}{
-{"1.0.0", "2.0.0", "major"},
-{"1.0.0", "1.1.0", "minor"},
-{"1.0.0", "1.0.1", "patch"},
-{"1.2.3", "2.0.0", "major"},
-{"1.2.3", "1.3.0", "minor"},
-{"1.2.3", "1.2.4", "patch"},
-{"0.1.0", "1.0.0", "major"},
-{"0.0.1", "0.0.2", "patch"},
-{"0.0.1", "0.1.0", "minor"},
-}
+	tests := []struct {
+		current string
+		latest  string
+		want    string
+	}{
+		{"1.0.0", "2.0.0", "major"},
+		{"1.0.0", "1.1.0", "minor"},
+		{"1.0.0", "1.0.1", "patch"},
+		{"1.2.3", "2.0.0", "major"},
+		{"1.2.3", "1.3.0", "minor"},
+		{"1.2.3", "1.2.4", "patch"},
+		{"0.1.0", "1.0.0", "major"},
+		{"0.0.1", "0.0.2", "patch"},
+		{"0.0.1", "0.1.0", "minor"},
+	}
 
-for _, tt := range tests {
-t.Run(tt.current+"→"+tt.latest, func(t *testing.T) {
-got := classifyUpdate(tt.current, tt.latest)
-if got != tt.want {
-t.Errorf("classifyUpdate(%q, %q) = %q, want %q", tt.current, tt.latest, got, tt.want)
-}
-})
-}
+	for _, tt := range tests {
+		t.Run(tt.current+"→"+tt.latest, func(t *testing.T) {
+			got := classifyUpdate(tt.current, tt.latest)
+			if got != tt.want {
+				t.Errorf("classifyUpdate(%q, %q) = %q, want %q", tt.current, tt.latest, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestSilentExitError(t *testing.T) {
-err := &silentExitError{code: 1}
-if err.Error() != "exit status 1" {
-t.Errorf("silentExitError.Error() = %q, want %q", err.Error(), "exit status 1")
-}
+	err := &silentExitError{code: 1}
+	if err.Error() != "exit status 1" {
+		t.Errorf("silentExitError.Error() = %q, want %q", err.Error(), "exit status 1")
+	}
 }
 
 func TestOutdatedZeroDependencies(t *testing.T) {
-dir := t.TempDir()
-testChdir(t, dir)
+	dir := t.TempDir()
+	testChdir(t, dir)
 
-testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
+	testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
 name: test-pkg
 version: 1.0.0
 skills:
   - skills/local
 `))
 
-testWriteFile(t, "craft.pin.yaml", []byte(`pin_version: 1
+	testWriteFile(t, "craft.pin.yaml", []byte(`pin_version: 1
 resolved: {}
 `))
 
-buf := new(bytes.Buffer)
-rootCmd.SetOut(buf)
-rootCmd.SetErr(new(bytes.Buffer))
-rootCmd.SetArgs([]string{"outdated"})
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"outdated"})
 
-err := rootCmd.Execute()
-if err != nil {
-t.Fatalf("outdated with zero deps should not error: %v", err)
-}
-if !strings.Contains(buf.String(), "No dependencies to check") {
-t.Errorf("expected 'No dependencies to check', got %q", buf.String())
-}
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("outdated with zero deps should not error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No dependencies to check") {
+		t.Errorf("expected 'No dependencies to check', got %q", buf.String())
+	}
 }
 
 func TestOutdatedNoPinfile(t *testing.T) {
-dir := t.TempDir()
-testChdir(t, dir)
+	dir := t.TempDir()
+	testChdir(t, dir)
 
-testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
+	testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
 name: test-pkg
 version: 1.0.0
 skills:
@@ -84,97 +84,97 @@ dependencies:
   my-dep: github.com/org/repo@v1.0.0
 `))
 
-buf := new(bytes.Buffer)
-rootCmd.SetOut(buf)
-rootCmd.SetErr(new(bytes.Buffer))
-rootCmd.SetArgs([]string{"outdated"})
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"outdated"})
 
-err := rootCmd.Execute()
-if err == nil {
-t.Fatal("outdated should error when no pinfile exists")
-}
-if !strings.Contains(err.Error(), "craft.pin.yaml not found") {
-t.Errorf("error should mention missing pinfile, got %q", err.Error())
-}
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("outdated should error when no pinfile exists")
+	}
+	if !strings.Contains(err.Error(), "craft.pin.yaml not found") {
+		t.Errorf("error should mention missing pinfile, got %q", err.Error())
+	}
 }
 
 func TestPrintDryRunSummary(t *testing.T) {
-result := &resolve.ResolveResult{
-Resolved: []resolve.ResolvedDep{
-{
-Alias:  "my-dep",
-URL:    "github.com/org/repo@v1.0.0",
-Skills: []string{"skill-a", "skill-b"},
-},
-},
-}
+	result := &resolve.ResolveResult{
+		Resolved: []resolve.ResolvedDep{
+			{
+				Alias:  "my-dep",
+				URL:    "github.com/org/repo@v1.0.0",
+				Skills: []string{"skill-a", "skill-b"},
+			},
+		},
+	}
 
-buf := new(bytes.Buffer)
-rootCmd.SetOut(buf)
-rootCmd.SetArgs([]string{"version"})
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"version"})
 
-printDryRunSummary(rootCmd, result, "+")
+	printDryRunSummary(rootCmd, result, "+")
 
-out := buf.String()
-if !strings.Contains(out, "Would resolve 1 dependency") {
-t.Errorf("dry-run summary should show dependency count, got %q", out)
-}
-if !strings.Contains(out, "my-dep") {
-t.Errorf("dry-run summary should show alias, got %q", out)
-}
-if !strings.Contains(out, "No changes made") {
-t.Errorf("dry-run summary should say 'No changes made', got %q", out)
-}
+	out := buf.String()
+	if !strings.Contains(out, "Would resolve 1 dependency") {
+		t.Errorf("dry-run summary should show dependency count, got %q", out)
+	}
+	if !strings.Contains(out, "my-dep") {
+		t.Errorf("dry-run summary should show alias, got %q", out)
+	}
+	if !strings.Contains(out, "No changes made") {
+		t.Errorf("dry-run summary should say 'No changes made', got %q", out)
+	}
 }
 
 func TestInstallDryRunZeroDeps(t *testing.T) {
-dir := t.TempDir()
-testChdir(t, dir)
+	dir := t.TempDir()
+	testChdir(t, dir)
 
-testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
+	testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
 name: test-pkg
 version: 1.0.0
 skills:
   - skills/local
 `))
 
-buf := new(bytes.Buffer)
-rootCmd.SetOut(buf)
-rootCmd.SetErr(new(bytes.Buffer))
-rootCmd.SetArgs([]string{"install", "--dry-run"})
-t.Cleanup(func() { installDryRun = false })
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"install", "--dry-run"})
+	t.Cleanup(func() { installDryRun = false })
 
-err := rootCmd.Execute()
-if err != nil {
-t.Fatalf("install --dry-run with zero deps should not error: %v", err)
-}
-if !strings.Contains(buf.String(), "No dependencies to install") {
-t.Errorf("expected 'No dependencies to install', got %q", buf.String())
-}
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("install --dry-run with zero deps should not error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No dependencies to install") {
+		t.Errorf("expected 'No dependencies to install', got %q", buf.String())
+	}
 }
 
 func TestUpdateDryRunZeroDeps(t *testing.T) {
-dir := t.TempDir()
-testChdir(t, dir)
+	dir := t.TempDir()
+	testChdir(t, dir)
 
-testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
+	testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
 name: test-pkg
 version: 1.0.0
 skills:
   - skills/local
 `))
 
-buf := new(bytes.Buffer)
-rootCmd.SetOut(buf)
-rootCmd.SetErr(new(bytes.Buffer))
-rootCmd.SetArgs([]string{"update", "--dry-run"})
-t.Cleanup(func() { updateDryRun = false })
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"update", "--dry-run"})
+	t.Cleanup(func() { updateDryRun = false })
 
-err := rootCmd.Execute()
-if err != nil {
-t.Fatalf("update --dry-run with zero deps should not error: %v", err)
-}
-if !strings.Contains(buf.String(), "No dependencies to update") {
-t.Errorf("expected 'No dependencies to update', got %q", buf.String())
-}
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("update --dry-run with zero deps should not error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No dependencies to update") {
+		t.Errorf("expected 'No dependencies to update', got %q", buf.String())
+	}
 }

--- a/internal/cli/outdated_test.go
+++ b/internal/cli/outdated_test.go
@@ -1,39 +1,180 @@
 package cli
 
 import (
-	"testing"
+"bytes"
+"strings"
+"testing"
+
+"github.com/erdemtuna/craft/internal/resolve"
 )
 
 func TestClassifyUpdate(t *testing.T) {
-	tests := []struct {
-		current string
-		latest  string
-		want    string
-	}{
-		{"1.0.0", "2.0.0", "major"},
-		{"1.0.0", "1.1.0", "minor"},
-		{"1.0.0", "1.0.1", "patch"},
-		{"1.2.3", "2.0.0", "major"},
-		{"1.2.3", "1.3.0", "minor"},
-		{"1.2.3", "1.2.4", "patch"},
-		{"0.1.0", "1.0.0", "major"},
-		{"0.0.1", "0.0.2", "patch"},
-		{"0.0.1", "0.1.0", "minor"},
-	}
+tests := []struct {
+current string
+latest  string
+want    string
+}{
+{"1.0.0", "2.0.0", "major"},
+{"1.0.0", "1.1.0", "minor"},
+{"1.0.0", "1.0.1", "patch"},
+{"1.2.3", "2.0.0", "major"},
+{"1.2.3", "1.3.0", "minor"},
+{"1.2.3", "1.2.4", "patch"},
+{"0.1.0", "1.0.0", "major"},
+{"0.0.1", "0.0.2", "patch"},
+{"0.0.1", "0.1.0", "minor"},
+}
 
-	for _, tt := range tests {
-		t.Run(tt.current+"→"+tt.latest, func(t *testing.T) {
-			got := classifyUpdate(tt.current, tt.latest)
-			if got != tt.want {
-				t.Errorf("classifyUpdate(%q, %q) = %q, want %q", tt.current, tt.latest, got, tt.want)
-			}
-		})
-	}
+for _, tt := range tests {
+t.Run(tt.current+"→"+tt.latest, func(t *testing.T) {
+got := classifyUpdate(tt.current, tt.latest)
+if got != tt.want {
+t.Errorf("classifyUpdate(%q, %q) = %q, want %q", tt.current, tt.latest, got, tt.want)
+}
+})
+}
 }
 
 func TestSilentExitError(t *testing.T) {
-	err := &silentExitError{code: 1}
-	if err.Error() != "exit status 1" {
-		t.Errorf("silentExitError.Error() = %q, want %q", err.Error(), "exit status 1")
-	}
+err := &silentExitError{code: 1}
+if err.Error() != "exit status 1" {
+t.Errorf("silentExitError.Error() = %q, want %q", err.Error(), "exit status 1")
+}
+}
+
+func TestOutdatedZeroDependencies(t *testing.T) {
+dir := t.TempDir()
+testChdir(t, dir)
+
+testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
+name: test-pkg
+version: 1.0.0
+skills:
+  - skills/local
+`))
+
+testWriteFile(t, "craft.pin.yaml", []byte(`pin_version: 1
+resolved: {}
+`))
+
+buf := new(bytes.Buffer)
+rootCmd.SetOut(buf)
+rootCmd.SetErr(new(bytes.Buffer))
+rootCmd.SetArgs([]string{"outdated"})
+
+err := rootCmd.Execute()
+if err != nil {
+t.Fatalf("outdated with zero deps should not error: %v", err)
+}
+if !strings.Contains(buf.String(), "No dependencies to check") {
+t.Errorf("expected 'No dependencies to check', got %q", buf.String())
+}
+}
+
+func TestOutdatedNoPinfile(t *testing.T) {
+dir := t.TempDir()
+testChdir(t, dir)
+
+testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
+name: test-pkg
+version: 1.0.0
+skills:
+  - skills/local
+dependencies:
+  my-dep: github.com/org/repo@v1.0.0
+`))
+
+buf := new(bytes.Buffer)
+rootCmd.SetOut(buf)
+rootCmd.SetErr(new(bytes.Buffer))
+rootCmd.SetArgs([]string{"outdated"})
+
+err := rootCmd.Execute()
+if err == nil {
+t.Fatal("outdated should error when no pinfile exists")
+}
+if !strings.Contains(err.Error(), "craft.pin.yaml not found") {
+t.Errorf("error should mention missing pinfile, got %q", err.Error())
+}
+}
+
+func TestPrintDryRunSummary(t *testing.T) {
+result := &resolve.ResolveResult{
+Resolved: []resolve.ResolvedDep{
+{
+Alias:  "my-dep",
+URL:    "github.com/org/repo@v1.0.0",
+Skills: []string{"skill-a", "skill-b"},
+},
+},
+}
+
+buf := new(bytes.Buffer)
+rootCmd.SetOut(buf)
+rootCmd.SetArgs([]string{"version"})
+
+printDryRunSummary(rootCmd, result, "+")
+
+out := buf.String()
+if !strings.Contains(out, "Would resolve 1 dependency") {
+t.Errorf("dry-run summary should show dependency count, got %q", out)
+}
+if !strings.Contains(out, "my-dep") {
+t.Errorf("dry-run summary should show alias, got %q", out)
+}
+if !strings.Contains(out, "No changes made") {
+t.Errorf("dry-run summary should say 'No changes made', got %q", out)
+}
+}
+
+func TestInstallDryRunZeroDeps(t *testing.T) {
+dir := t.TempDir()
+testChdir(t, dir)
+
+testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
+name: test-pkg
+version: 1.0.0
+skills:
+  - skills/local
+`))
+
+buf := new(bytes.Buffer)
+rootCmd.SetOut(buf)
+rootCmd.SetErr(new(bytes.Buffer))
+rootCmd.SetArgs([]string{"install", "--dry-run"})
+t.Cleanup(func() { installDryRun = false })
+
+err := rootCmd.Execute()
+if err != nil {
+t.Fatalf("install --dry-run with zero deps should not error: %v", err)
+}
+if !strings.Contains(buf.String(), "No dependencies to install") {
+t.Errorf("expected 'No dependencies to install', got %q", buf.String())
+}
+}
+
+func TestUpdateDryRunZeroDeps(t *testing.T) {
+dir := t.TempDir()
+testChdir(t, dir)
+
+testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
+name: test-pkg
+version: 1.0.0
+skills:
+  - skills/local
+`))
+
+buf := new(bytes.Buffer)
+rootCmd.SetOut(buf)
+rootCmd.SetErr(new(bytes.Buffer))
+rootCmd.SetArgs([]string{"update", "--dry-run"})
+t.Cleanup(func() { updateDryRun = false })
+
+err := rootCmd.Execute()
+if err != nil {
+t.Fatalf("update --dry-run with zero deps should not error: %v", err)
+}
+if !strings.Contains(buf.String(), "No dependencies to update") {
+t.Errorf("expected 'No dependencies to update', got %q", buf.String())
+}
 }

--- a/internal/cli/outdated_test.go
+++ b/internal/cli/outdated_test.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"testing"
+)
+
+func TestClassifyUpdate(t *testing.T) {
+	tests := []struct {
+		current string
+		latest  string
+		want    string
+	}{
+		{"1.0.0", "2.0.0", "major"},
+		{"1.0.0", "1.1.0", "minor"},
+		{"1.0.0", "1.0.1", "patch"},
+		{"1.2.3", "2.0.0", "major"},
+		{"1.2.3", "1.3.0", "minor"},
+		{"1.2.3", "1.2.4", "patch"},
+		{"0.1.0", "1.0.0", "major"},
+		{"0.0.1", "0.0.2", "patch"},
+		{"0.0.1", "0.1.0", "minor"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.current+"→"+tt.latest, func(t *testing.T) {
+			got := classifyUpdate(tt.current, tt.latest)
+			if got != tt.want {
+				t.Errorf("classifyUpdate(%q, %q) = %q, want %q", tt.current, tt.latest, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSilentExitError(t *testing.T) {
+	err := &silentExitError{code: 1}
+	if err.Error() != "exit status 1" {
+		t.Errorf("silentExitError.Error() = %q, want %q", err.Error(), "exit status 1")
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -45,6 +45,8 @@ func Execute() error {
 }
 
 // silentExitError signals a non-zero exit code without printing an error message.
+// Used by commands like `craft outdated` that use exit code 1 as a signal (not an error).
+// The code field is currently always 1; it exists for future extensibility.
 type silentExitError struct {
 	code int
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -16,6 +16,8 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose diagnostic output")
+
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(validateCmd)
@@ -24,13 +26,29 @@ func init() {
 	rootCmd.AddCommand(addCmd)
 	rootCmd.AddCommand(removeCmd)
 	rootCmd.AddCommand(cacheCmd)
+	rootCmd.AddCommand(listCmd)
+	rootCmd.AddCommand(treeCmd)
+	rootCmd.AddCommand(outdatedCmd)
 }
 
 // Execute runs the root command.
 func Execute() error {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		// Don't print silent exit errors — they signal a non-zero
+		// exit code without an error message (e.g., craft outdated).
+		if _, ok := err.(*silentExitError); !ok {
+			fmt.Fprintln(os.Stderr, err)
+		}
 		return err
 	}
 	return nil
+}
+
+// silentExitError signals a non-zero exit code without printing an error message.
+type silentExitError struct {
+	code int
+}
+
+func (e *silentExitError) Error() string {
+	return fmt.Sprintf("exit status %d", e.code)
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -46,11 +46,20 @@ func Execute() error {
 
 // silentExitError signals a non-zero exit code without printing an error message.
 // Used by commands like `craft outdated` that use exit code 1 as a signal (not an error).
-// The code field is currently always 1; it exists for future extensibility.
 type silentExitError struct {
 	code int
 }
 
 func (e *silentExitError) Error() string {
 	return fmt.Sprintf("exit status %d", e.code)
+}
+
+// ExitCode returns the exit code from a silentExitError, or 0 if the error
+// is not a silentExitError. This is used by main.go to propagate the intended
+// exit code to os.Exit.
+func ExitCode(err error) int {
+	if se, ok := err.(*silentExitError); ok {
+		return se.code
+	}
+	return 1
 }

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -17,7 +17,7 @@ var treeCmd = &cobra.Command{
 }
 
 func runTree(cmd *cobra.Command, args []string) error {
-	m, pf, err := loadManifestAndPinfile()
+	m, pf, err := requireManifestAndPinfile()
 	if err != nil {
 		return err
 	}
@@ -51,6 +51,7 @@ func runTree(cmd *cobra.Command, args []string) error {
 	for key, entry := range pf.Resolved {
 		parsed, err := resolve.ParseDepURL(key)
 		if err != nil {
+			verboseLog(cmd, "Skipping unparseable pinfile key: %s", key)
 			continue
 		}
 

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"strings"
+
+	"github.com/erdemtuna/craft/internal/resolve"
+	"github.com/erdemtuna/craft/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var treeCmd = &cobra.Command{
+	Use:   "tree",
+	Short: "Print dependency tree",
+	Long:  "Display the dependency tree showing local skills and all resolved dependencies with their skills.",
+	Args:  cobra.NoArgs,
+	RunE:  runTree,
+}
+
+func runTree(cmd *cobra.Command, args []string) error {
+	m, pf, err := loadManifestAndPinfile()
+	if err != nil {
+		return err
+	}
+
+	verboseLog(cmd, "Loaded manifest: %s@%s", m.Name, m.Version)
+
+	packageName := m.Name
+	if m.Version != "" {
+		packageName += "@" + m.Version
+	}
+
+	// Extract local skill names from paths
+	var localSkills []string
+	for _, s := range m.Skills {
+		parts := strings.Split(strings.TrimRight(s, "/"), "/")
+		localSkills = append(localSkills, parts[len(parts)-1])
+	}
+
+	// Build alias lookup from manifest
+	urlToAlias := make(map[string]string)
+	for alias, depURL := range m.Dependencies {
+		parsed, err := resolve.ParseDepURL(depURL)
+		if err != nil {
+			continue
+		}
+		urlToAlias[parsed.PackageIdentity()] = alias
+	}
+
+	// Build dep nodes from pinfile
+	var deps []ui.DepNode
+	for key, entry := range pf.Resolved {
+		parsed, err := resolve.ParseDepURL(key)
+		if err != nil {
+			continue
+		}
+
+		alias := urlToAlias[parsed.PackageIdentity()]
+		if alias == "" {
+			alias = parsed.Repo
+		}
+
+		deps = append(deps, ui.DepNode{
+			Alias:  alias,
+			URL:    key,
+			Skills: entry.Skills,
+		})
+	}
+
+	ui.RenderTree(cmd.OutOrStdout(), packageName, localSkills, deps)
+	return nil
+}

--- a/internal/cli/tree_test.go
+++ b/internal/cli/tree_test.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestTreeWithDependencies(t *testing.T) {
+	dir := t.TempDir()
+	testChdir(t, dir)
+
+	testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
+name: test-pkg
+version: 1.0.0
+skills:
+  - skills/local-skill
+dependencies:
+  my-dep: github.com/org/repo@v1.2.0
+`))
+
+	testWriteFile(t, "craft.pin.yaml", []byte(`pin_version: 1
+resolved:
+  github.com/org/repo@v1.2.0:
+    commit: abc123
+    integrity: sha256-test
+    skills:
+      - remote-skill
+`))
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"tree"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("tree command failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "test-pkg@1.0.0") {
+		t.Errorf("tree should show package name, got %q", output)
+	}
+	if !strings.Contains(output, "local-skill") {
+		t.Errorf("tree should show local skills, got %q", output)
+	}
+	if !strings.Contains(output, "my-dep") {
+		t.Errorf("tree should show dependency alias, got %q", output)
+	}
+	if !strings.Contains(output, "remote-skill") {
+		t.Errorf("tree should show remote skills, got %q", output)
+	}
+}
+
+func TestTreeNoDependencies(t *testing.T) {
+	dir := t.TempDir()
+	testChdir(t, dir)
+
+	testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
+name: test-pkg
+version: 1.0.0
+skills:
+  - skills/local-skill
+`))
+
+	testWriteFile(t, "craft.pin.yaml", []byte(`pin_version: 1
+resolved: {}
+`))
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"tree"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("tree command failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "test-pkg@1.0.0") {
+		t.Errorf("tree should show package name, got %q", output)
+	}
+	if !strings.Contains(output, "local-skill") {
+		t.Errorf("tree should show local skills, got %q", output)
+	}
+}
+
+func TestTreeNoPinfile(t *testing.T) {
+	dir := t.TempDir()
+	testChdir(t, dir)
+
+	testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
+name: test-pkg
+version: 1.0.0
+skills:
+  - skills/local
+`))
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"tree"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("tree should error when no pinfile exists")
+	}
+	if !strings.Contains(err.Error(), "craft.pin.yaml not found") {
+		t.Errorf("error should mention missing pinfile, got %q", err.Error())
+	}
+}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -19,6 +19,7 @@ import (
 )
 
 var updateTarget string
+var updateDryRun bool
 
 var updateCmd = &cobra.Command{
 	Use:   "update [alias]",
@@ -30,6 +31,7 @@ var updateCmd = &cobra.Command{
 
 func init() {
 	updateCmd.Flags().StringVar(&updateTarget, "target", "", "Override agent auto-detection with a custom install path")
+	updateCmd.Flags().BoolVar(&updateDryRun, "dry-run", false, "Show what would be updated without making changes")
 }
 
 func runUpdate(cmd *cobra.Command, args []string) error {
@@ -138,6 +140,13 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		progress.Fail("Resolution failed")
 		return fmt.Errorf("resolution failed: %w", err)
+	}
+
+	// Dry-run: show what would change and exit
+	if updateDryRun {
+		progress.Done("Dry-run complete")
+		printDryRunSummary(cmd, result, "~")
+		return nil
 	}
 
 	if err := writePinfileAtomic(pfPath, result.Pinfile); err != nil {

--- a/internal/cli/verbose.go
+++ b/internal/cli/verbose.go
@@ -14,7 +14,7 @@ var verbose bool
 // verboseLog writes a message to stderr when verbose mode is enabled.
 func verboseLog(cmd *cobra.Command, format string, args ...any) {
 	if verbose {
-		fmt.Fprintf(cmd.ErrOrStderr(), format+"\n", args...)
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), format+"\n", args...)
 	}
 }
 

--- a/internal/cli/verbose.go
+++ b/internal/cli/verbose.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"fmt"
+	"strings"
+	"unicode"
 
 	"github.com/spf13/cobra"
 )
@@ -14,4 +16,19 @@ func verboseLog(cmd *cobra.Command, format string, args ...any) {
 	if verbose {
 		fmt.Fprintf(cmd.ErrOrStderr(), format+"\n", args...)
 	}
+}
+
+// sanitize strips control characters (except tab and newline) from a string
+// to prevent terminal escape injection from untrusted input like dependency
+// aliases, URLs, and skill names.
+func sanitize(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' || r == '\n' {
+			return r
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
 }

--- a/internal/cli/verbose.go
+++ b/internal/cli/verbose.go
@@ -1,0 +1,17 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// verbose controls whether verbose diagnostic output is enabled.
+var verbose bool
+
+// verboseLog writes a message to stderr when verbose mode is enabled.
+func verboseLog(cmd *cobra.Command, format string, args ...any) {
+	if verbose {
+		fmt.Fprintf(cmd.ErrOrStderr(), format+"\n", args...)
+	}
+}

--- a/internal/cli/verbose_test.go
+++ b/internal/cli/verbose_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -61,5 +62,90 @@ func TestVerboseLog_Disabled(t *testing.T) {
 	output := buf.String()
 	if output != "" {
 		t.Errorf("verbose log should be empty when disabled, got %q", output)
+	}
+}
+
+func TestSanitize(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"clean string", "hello-world", "hello-world"},
+		{"with tab", "hello\tworld", "hello\tworld"},
+		{"with newline", "hello\nworld", "hello\nworld"},
+		{"with escape", "hello\x1b[31mworld\x1b[0m", "hello[31mworld[0m"},
+		{"with null", "hello\x00world", "helloworld"},
+		{"with bell", "hello\x07world", "helloworld"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitize(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitize(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVerboseListOutput(t *testing.T) {
+	dir := t.TempDir()
+	testChdir(t, dir)
+
+	testWriteFile(t, "craft.yaml", []byte(`schema_version: 1
+name: test-pkg
+version: 1.0.0
+skills:
+  - skills/local
+dependencies:
+  my-dep: github.com/org/repo@v1.2.0
+`))
+
+	testWriteFile(t, "craft.pin.yaml", []byte(`pin_version: 1
+resolved:
+  github.com/org/repo@v1.2.0:
+    commit: abc123
+    integrity: sha256-test
+    skills:
+      - skill-a
+`))
+
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"list", "--verbose"})
+	t.Cleanup(func() { verbose = false })
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("list --verbose failed: %v", err)
+	}
+
+	errOutput := errBuf.String()
+	if !strings.Contains(errOutput, "Loaded manifest") {
+		t.Errorf("verbose list should emit diagnostic to stderr, got %q", errOutput)
+	}
+}
+
+func TestExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"silent exit 1", &silentExitError{code: 1}, 1},
+		{"silent exit 2", &silentExitError{code: 2}, 2},
+		{"regular error", fmt.Errorf("some error"), 1},
+		{"nil error", nil, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExitCode(tt.err)
+			if got != tt.want {
+				t.Errorf("ExitCode(%v) = %d, want %d", tt.err, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/cli/verbose_test.go
+++ b/internal/cli/verbose_test.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestVerboseFlag(t *testing.T) {
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"version", "--verbose"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("version --verbose should not error: %v", err)
+	}
+}
+
+func TestVerboseShorthand(t *testing.T) {
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"version", "-v"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("version -v should not error: %v", err)
+	}
+}
+
+func TestVerboseLog_Enabled(t *testing.T) {
+	oldVerbose := verbose
+	defer func() { verbose = oldVerbose }()
+	verbose = true
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"version"})
+
+	// Use verboseLog directly
+	verboseLog(rootCmd, "test message %d", 42)
+
+	output := buf.String()
+	if !strings.Contains(output, "test message 42") {
+		t.Errorf("verbose log should contain message, got %q", output)
+	}
+}
+
+func TestVerboseLog_Disabled(t *testing.T) {
+	oldVerbose := verbose
+	defer func() { verbose = oldVerbose }()
+	verbose = false
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetErr(buf)
+
+	verboseLog(rootCmd, "should not appear")
+
+	output := buf.String()
+	if output != "" {
+		t.Errorf("verbose log should be empty when disabled, got %q", output)
+	}
+}

--- a/internal/cli/verbose_test.go
+++ b/internal/cli/verbose_test.go
@@ -10,6 +10,7 @@ func TestVerboseFlag(t *testing.T) {
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetArgs([]string{"version", "--verbose"})
+	t.Cleanup(func() { verbose = false })
 
 	err := rootCmd.Execute()
 	if err != nil {
@@ -21,6 +22,7 @@ func TestVerboseShorthand(t *testing.T) {
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetArgs([]string{"version", "-v"})
+	t.Cleanup(func() { verbose = false })
 
 	err := rootCmd.Execute()
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds five CLI features to bring craft to package-manager parity. Three new read-only commands for dependency introspection, a global verbose flag for diagnostics, and a dry-run flag for safe operation preview.

### New Commands
- **`craft list`** — Show resolved dependencies with versions and skill counts. Supports `--detailed` flag for URLs and individual skill names.
- **`craft tree`** — Standalone ASCII dependency tree visualization, reusing existing `ui.RenderTree()`.
- **`craft outdated`** — Check direct dependencies for newer semver versions, classify updates as major/minor/patch. Exits code 1 when updates available (CI-friendly).

### New Flags
- **`--verbose` / `-v`** — Global persistent flag for diagnostic output on all commands (stderr).
- **`--dry-run`** — On `install` and `update`, runs full resolution but prevents all file writes.

### Infrastructure
- `silentExitError` + `ExitCode()` — Non-zero exit without error message printing, with proper exit code propagation to `main.go`.
- `requireManifestAndPinfile()` — Shared helper for consistent pinfile/manifest error handling.
- `printDryRunSummary()` — Shared dry-run output formatter.
- `sanitize()` — Terminal escape sequence stripping on all user-controlled output to prevent injection.

## Changes

| Area | Files | Description |
|------|-------|-------------|
| New commands | `list.go`, `tree.go`, `outdated.go` | Three read-only commands with tests |
| Global flag | `verbose.go`, `root.go` | `--verbose`/`-v` persistent flag + `verboseLog()` helper |
| Dry-run | `install.go`, `update.go` | `--dry-run` flag with early-return after resolution |
| Shared helpers | `helpers.go` | `requireManifestAndPinfile()`, `printDryRunSummary()` |
| Security | `verbose.go` | `sanitize()` strips control chars from dependency aliases/URLs/skills |
| Exit codes | `root.go`, `cmd/craft/main.go` | `silentExitError` + `ExitCode()` wiring |
| Tests | `*_test.go` (6 files) | 35 new test cases |
| Docs | `README.md` | Commands table, usage examples, flag documentation |

## Testing

- **35 new test cases** covering all commands, flags, and edge cases
- Sort order verification (multi-dependency), zero-skills edge case, test state isolation
- `sanitize()` tests: escape sequences, null bytes, bell chars, clean strings
- `ExitCode()` tests: silent exit codes, regular errors
- Verbose wiring test: verifies `craft list --verbose` produces stderr output
- All 15 packages pass: `go test ./...` ✅
- `go vet ./...` ✅, `go build` ✅

## Review Notes

- All features are **additive** — no existing behavior changes
- Reviewed via **Society-of-Thought** with 5 specialist reviewers (correctness, testing, edge-cases, architecture, security)
- Key fixes from SoT review:
  - `craft outdated` was showing deps with no semver tags as "(up to date)" — fixed to skip with warning
  - `silentExitError.code` was unused by `main.go` — wired via `ExitCode()` helper
  - Terminal escape injection — added `sanitize()` on all user-controlled output
  - Deterministic `outdated` verbose output — sorted dependency iteration
  - `printDryRunSummary` zero-skills formatting fix

### Not addressed (pre-existing, out of scope)
- `CRAFT_TOKEN` default-allow for unknown hosts — systemic auth design, deserves own PR
- Verbose output includes repo URLs — opt-in, user-owned data

## Artifacts

> Workflow artifacts are committed on the branch (`commit-and-persist` lifecycle).

| Artifact | Link |
|----------|------|
| Spec | [Spec.md](.paw/work/cli-feature-bundle/Spec.md) |
| Code Research | [CodeResearch.md](.paw/work/cli-feature-bundle/CodeResearch.md) |
| Implementation Plan | [ImplementationPlan.md](.paw/work/cli-feature-bundle/ImplementationPlan.md) |
| Documentation | [Docs.md](.paw/work/cli-feature-bundle/Docs.md) |

---

🐾 Generated with [PAW](https://github.com/lossyrob/phased-agent-workflow)
