### PR TITLE
[Namespaced Skill Install] Namespace installed skills by host/owner/repo

### DIFF
--- a/.paw/work/namespaced-skill-install/Spec.md
+++ b/.paw/work/namespaced-skill-install/Spec.md
@@ -1,0 +1,130 @@
+# Feature Specification: Namespaced Skill Installation
+
+**Branch**: feature/namespaced-skill-install  |  **Created**: 2026-03-09  |  **Status**: Draft
+**Input Brief**: Allow same-name skills from different dependencies by namespacing install paths with host/owner/repo.
+
+## Overview
+
+Craft is a skill package manager that resolves, installs, and manages skills from multiple git-hosted dependencies. Today, all dependency skills install into a flat directory structure under the install target — each skill occupies `<target>/<skill-name>/`. When two independent dependencies export a skill with the same name, craft hard-errors with a collision, preventing installation entirely.
+
+This is a real-world problem: the PAW workflow repository and Anthropic's skills repository both export a skill named `skill-creator`. Users who want both dependencies in their package cannot proceed. The collision check is overly strict — independent repositories will naturally have overlapping skill names, and users should be able to use both without conflict.
+
+The solution is to namespace installed skills by their source repository identity. By using the dependency URL's `host/owner/repo` as a directory prefix, skills from different sources occupy distinct paths on disk. Two `skill-creator` skills coexist peacefully because they live under `github.com/lossyrob/phased-agent-workflow/skill-creator/` and `github.com/anthropics/skills/skill-creator/` respectively.
+
+This approach mirrors Go module paths — a convention craft users already understand — and works uniformly for all git hosts (GitHub, GitLab, Bitbucket, self-hosted), for both direct and transitive dependencies.
+
+## Objectives
+
+- Enable users to depend on multiple repositories that export same-name skills without errors
+- Provide a deterministic, globally unique install layout that cannot collide regardless of host, owner, or repo
+- Maintain correct cleanup behavior when dependencies are removed
+- Preserve existing behavior for local skills (which are not installed by craft)
+
+## User Scenarios & Testing
+
+### User Story P1 – Install dependencies with overlapping skill names
+
+Narrative: A developer adds two dependencies to their craft package. Both export a skill called `skill-creator`. They run `craft install` and both dependencies' skills are installed without error, each under its own namespaced directory.
+
+Independent Test: Run `craft install` with two dependencies that share a skill name and verify both skills exist on disk at distinct paths.
+
+Acceptance Scenarios:
+1. Given a craft.yaml with two dependencies that each export `skill-creator`, When the user runs `craft install`, Then both skills are installed under `<target>/<host>/<owner>/<repo>/skill-creator/` with no error.
+2. Given a craft.yaml with two dependencies that have no overlapping skill names, When the user runs `craft install`, Then all skills are installed under their respective `<host>/<owner>/<repo>/` namespaces.
+3. Given a craft.yaml with a single dependency, When the user runs `craft install`, Then skills are installed under `<target>/<host>/<owner>/<repo>/<skill-name>/`.
+
+### User Story P2 – Remove a dependency with overlapping skill names
+
+Narrative: A developer has two installed dependencies sharing a skill name. They remove one dependency and expect only that dependency's skills to be cleaned up, while the other dependency's identically-named skill remains intact.
+
+Independent Test: Run `craft remove` for one dependency and verify the other dependency's same-name skill still exists at its namespaced path.
+
+Acceptance Scenarios:
+1. Given two installed dependencies both exporting `skill-creator`, When the user removes one dependency, Then only that dependency's `skill-creator` is deleted, and the other dependency's `skill-creator` remains.
+2. Given a removed dependency was the only one from its owner, When `craft remove` completes, Then the empty `<host>/<owner>/<repo>/` directory tree is cleaned up.
+
+### User Story P3 – Update a dependency preserves namespaced layout
+
+Narrative: A developer updates a dependency to a newer version. The updated skills are re-installed under the same namespaced path.
+
+Independent Test: Run `craft update` and verify skills remain at `<target>/<host>/<owner>/<repo>/<skill-name>/`.
+
+Acceptance Scenarios:
+1. Given an installed dependency at v1.0.0, When the user runs `craft update` and the dependency bumps to v2.0.0, Then skills are re-installed under the same `<host>/<owner>/<repo>/` namespace with updated content.
+
+### User Story P4 – Add a dependency that would have previously collided
+
+Narrative: A developer already has a dependency installed. They add a second dependency that exports a skill with the same name. The add succeeds without a collision error.
+
+Independent Test: Run `craft add` for a dependency whose skills overlap with an existing dependency, and verify success.
+
+Acceptance Scenarios:
+1. Given an existing dependency exporting `skill-creator`, When the user runs `craft add` for a second dependency also exporting `skill-creator`, Then the add succeeds and manifest is updated.
+
+### Edge Cases
+
+- Empty parent directories (`<host>/<owner>/`, `<host>/`) are cleaned up after skill removal when no other skills remain under them.
+- A dependency that exports zero skills still resolves and installs without error (no namespace directory created).
+- Skills with path-separator characters in their names are rejected by existing path traversal checks (existing behavior, unchanged).
+- Non-GitHub hosts (GitLab, Bitbucket, self-hosted) produce valid namespace paths (e.g., `gitlab.com/org/repo/skill-name/`).
+
+## Requirements
+
+### Functional Requirements
+
+- FR-001: Dependency skills are installed under `<target>/<host>/<owner>/<repo>/<skill-name>/` where host, owner, and repo are parsed from the dependency URL. (Stories: P1)
+- FR-002: The cross-dependency collision detection (`detectCollisions`) is removed from the resolver — same-name skills across different dependencies are permitted. (Stories: P1, P4)
+- FR-003: Skill removal constructs cleanup paths using `<host>/<owner>/<repo>/<skill-name>/` and removes empty ancestor directories up to the target root. (Stories: P2)
+- FR-004: Skill updates re-install under the same `<host>/<owner>/<repo>/` namespace. (Stories: P3)
+- FR-005: The local skill duplicate name validation within a single package is preserved. (Stories: P1)
+- FR-006: The `Install()` function signature remains unchanged — namespacing is achieved by using composite keys (`host/owner/repo/skillName`) in the existing skill map. (Stories: P1)
+
+### Cross-Cutting / Non-Functional
+
+- Existing path traversal security checks continue to function correctly with deeper directory nesting.
+- Atomic install via staging directories continues to work with composite keys.
+
+## Success Criteria
+
+- SC-001: Two dependencies exporting the same skill name can be added, installed, and used without any error. (FR-001, FR-002)
+- SC-002: After removing one of two dependencies that share a skill name, the remaining dependency's skill is intact and the removed dependency's skill is gone. (FR-003)
+- SC-003: Empty ancestor directories are cleaned up after the last skill under them is removed. (FR-003)
+- SC-004: All existing tests pass (updated for new paths) and new tests cover the namespaced layout. (FR-001 through FR-006)
+- SC-005: Skills from non-GitHub hosts install under the correct host-prefixed path. (FR-001)
+
+## Assumptions
+
+- There are no existing craft users who need migration from the flat layout to the namespaced layout. (Confirmed during shaping.)
+- The `DepURL` struct already exposes `Host`, `Org`, and `Repo` fields sufficient to construct the namespace prefix. (Verified in `internal/resolve/depurl.go`.)
+- Local skills are not installed by craft and require no changes. (Verified in `internal/cli/install.go`.)
+
+## Scope
+
+In Scope:
+- Namespaced install layout for all dependency skills (direct and transitive)
+- Removal of `detectCollisions()` from resolver
+- Updated cleanup logic in `craft remove`
+- Test updates for new expected paths
+- E2E test documentation updates
+
+Out of Scope:
+- Local skill installation changes (local skills stay in-repo)
+- Alias-based symlinks for shorter references (see [issue #27](https://github.com/erdemtuna/craft/issues/27))
+- Pinfile structure changes (existing structure is sufficient)
+- Migration tooling for existing flat layouts
+
+## Dependencies
+
+- `internal/resolve/depurl.go` — `ParseDepURL()` and `DepURL` struct for extracting host/owner/repo
+- Existing path traversal security in `internal/install/installer.go`
+
+## Risks & Mitigations
+
+- **Deeper directory nesting may affect downstream tool discovery**: Tools consuming installed skills may expect a flat `<target>/*/SKILL.md` pattern. Mitigation: This is the consumer's responsibility; craft's job is conflict-free installation. Document the new layout.
+- **Composite key with `/` in map keys could cause confusion**: Developers might mistake the composite key for a simple skill name. Mitigation: The `Install()` function treats it as a path naturally via `filepath.Join` — no special handling needed.
+
+## References
+
+- WorkShaping: `.paw/work/namespaced-skill-install/WorkShaping.md` (session artifact)
+- E2E test scenario: `E2E_REAL_WORLD_TEST.md`
+- Alias symlinks follow-up: [issue #27](https://github.com/erdemtuna/craft/issues/27)

--- a/.paw/work/namespaced-skill-install/WorkShaping.md
+++ b/.paw/work/namespaced-skill-install/WorkShaping.md
@@ -1,0 +1,113 @@
+# WorkShaping: Namespace Skills by Host/Owner/Repo
+
+## Problem Statement
+
+When two direct dependencies export a skill with the same name (e.g., `skill-creator` from both `lossyrob/phased-agent-workflow` and `anthropics/skills`), craft hard-errors with a collision. This is the real-world scenario from the E2E test: PAW exports `skill-creator` from its `.github/` folder, and Anthropic exports it as a primary skill.
+
+The collision exists because skills install **flat** into `<target>/<skill-name>/`, so two `skill-creator` directories would overwrite each other. The fix is to **namespace skills by `host/owner/repo`** parsed from the dependency URL.
+
+## Desired Outcome
+
+Dependency skills install under `<target>/<host>/<owner>/<repo>/<skill-name>/`:
+
+```
+<target>/
+├── github.com/
+│   ├── lossyrob/
+│   │   └── phased-agent-workflow/
+│   │       ├── paw-implement/
+│   │       ├── paw-spec/
+│   │       └── skill-creator/         ← from PAW — no conflict
+│   └── anthropics/
+│       └── skills/
+│           ├── pdf/
+│           └── skill-creator/         ← from Anthropic — no conflict
+└── gitlab.com/                        ← non-GitHub hosts work too
+    └── corp/
+        └── internal-skills/
+            └── deploy/
+```
+
+Local skills (declared in `craft.yaml`'s `skills:` field) are **not installed** by craft — they stay in-repo, version-controlled, consumed from their original location. This change only affects dependency skills.
+
+## Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Namespace key | `host/owner/repo` from dependency URL | Globally unique across all git hosts, deterministic, stable across alias renames, works for transitives |
+| Local skills | Not affected (not installed) | `collectSkillFiles()` only processes `result.Resolved` — local skills stay in-repo |
+| Transitive deps | Naturally handled | Every dep has a URL with `owner/repo`, so transitives get namespaced too |
+| Cross-dep collision detection | **Remove entirely** (`detectCollisions`) | Namespacing makes cross-dep collisions impossible |
+| Local collision check | **Keep** in validator | Same package shouldn't export duplicate skill names |
+| Migration | Not needed | No existing craft users to migrate |
+| `Install()` signature | **Unchanged** | Use composite key `"owner/repo/skillName"` in existing `map[string]map[string][]byte` — `filepath.Join` naturally creates nested dirs |
+
+## Scope
+
+### In Scope
+- Change install layout: dependency skills go under `<target>/<host>/<owner>/<repo>/<skill-name>/`
+- Namespace derived from parsed dependency URL (`host/owner/repo`), not user alias
+- Remove `detectCollisions()` from resolver
+- Update `collectSkillFiles` to prefix keys with `host/owner/repo/`
+- Update `craft remove` cleanup for new paths; clean empty host/owner/repo dirs
+- Update all affected tests
+- Update `E2E_REAL_WORLD_TEST.md` expected paths
+
+### Out of Scope
+- Local skill installation (they aren't installed today, no change needed)
+- Backwards-compatible migration of old flat layout (no existing users)
+- Changes to pinfile structure (already tracks per-dep URL)
+
+## Codebase Context
+
+### Current Install Flow
+1. **Resolver** (`internal/resolve/resolver.go`): Resolves deps → `[]ResolvedDep` (each has `URL`, `Alias`, `Skills[]`, `SkillPaths[]`)
+2. **Resolver phase 5**: `detectCollisions()` — hard-errors if any skill name appears in 2+ deps
+3. **CLI install** (`internal/cli/install.go`): `collectSkillFiles()` fetches skill file contents, returns `map[skillName]map[filePath][]byte` — **flat, no namespace**
+4. **Installer** (`internal/install/installer.go`): `Install(target, skills)` writes to `<target>/<skillName>/<files>`
+
+### Implementation Approach: Composite Key
+Instead of changing `Install()`'s signature, use `"host/owner/repo/skillName"` as the map key:
+
+```go
+// In collectSkillFiles — change the key:
+parsed, _ := resolve.ParseDepURL(dep.URL)  // DepURL has Host, Org, Repo fields
+prefix := parsed.Host + "/" + parsed.Org + "/" + parsed.Repo
+skills[prefix + "/" + skillName] = files
+// e.g. "github.com/lossyrob/phased-agent-workflow/paw-implement"
+// e.g. "github.com/anthropics/skills/skill-creator"
+```
+
+`Install()` calls `filepath.Join(target, skillName)` which naturally creates `target/github.com/lossyrob/phased-agent-workflow/paw-implement`. The path traversal check still passes — the path stays within target. The `.staging` directory becomes `target/github.com/lossyrob/phased-agent-workflow/paw-implement.staging` — still correct.
+
+### Key Function Signatures (unchanged)
+- `Install(target string, skills map[string]map[string][]byte) error` — **no change needed**
+- `collectSkillFiles(fetcher, result) map[string]map[string][]byte` — prefix keys with `host/owner/repo/`
+- `detectCollisions(resolved []ResolvedDep) error` — **to be removed**
+- `DepURL` struct — already has `Host`, `Org`, `Repo` fields parsed from URL
+
+### Files to Change
+1. `internal/cli/install.go` — `collectSkillFiles` prefixes map keys with `host/owner/repo/` parsed from `dep.URL`
+2. `internal/cli/update.go` — Same install path changes (shares `collectSkillFiles`)
+3. `internal/cli/remove.go` — Use `host/owner/repo/skillName` in cleanup paths; clean empty parent dirs
+4. `internal/resolve/resolver.go` — Remove `detectCollisions()` function and its call in `Resolve()`
+5. `internal/install/installer.go` — **No changes needed** (composite key works naturally)
+6. `internal/cli/add.go` — No changes needed (collision check was inside `Resolve()`)
+7. `internal/validate/runner.go` — No changes needed (local collision check is separate)
+8. Tests for install, resolve, remove
+9. `E2E_REAL_WORLD_TEST.md` — Update expected install paths
+
+## Open Questions
+
+_None — all design decisions resolved during shaping._
+
+## Future Enhancement
+
+- **Alias symlinks** for shorter skill-to-skill references — see [issue #27](https://github.com/erdemtuna/craft/issues/27)
+
+## References
+
+- E2E test scenario: `E2E_REAL_WORLD_TEST.md` (PAW + Anthropic skills, both export `skill-creator`)
+- Current collision error: `internal/resolve/resolver.go` lines 509-534
+- Install layout: `internal/install/installer.go` `Install()` function
+- URL parsing: `internal/resolve/depurl.go` — `DepURL` struct has `Host`, `Org`, `Repo` fields

--- a/.paw/work/namespaced-skill-install/WorkflowContext.md
+++ b/.paw/work/namespaced-skill-install/WorkflowContext.md
@@ -1,0 +1,30 @@
+# WorkflowContext
+
+Work Title: Namespaced Skill Install
+Work ID: namespaced-skill-install
+Base Branch: main
+Target Branch: feature/namespaced-skill-install
+Workflow Mode: full
+Review Strategy: local
+Review Policy: final_only
+Session Policy: continuous
+Final Agent Review: enabled
+Final Review Mode: sot
+Final Review Interactive: smart
+Final Review Models: gpt-5.2, gemini-3-pro-preview, claude-opus-4.6
+Final Review Specialists: all
+Final Review Interaction Mode: parallel
+Final Review Specialist Models: none
+Plan Generation Mode: single-model
+Plan Generation Models: gpt-5.2, gemini-3-pro-preview, claude-opus-4.6
+Planning Docs Review: enabled
+Planning Review Mode: single-model
+Planning Review Interactive: smart
+Planning Review Models: gpt-5.2, gemini-3-pro-preview, claude-opus-4.6
+Custom Workflow Instructions: none
+Initial Prompt: Namespace dependency skills by host/owner/repo to allow same-name skills from different dependencies
+Issue URL: none
+Remote: origin
+Artifact Lifecycle: persist
+Artifact Paths: auto-derived
+Additional Inputs: none

--- a/.paw/work/namespaced-skill-install/reviews/REVIEW-ARCHITECTURE.md
+++ b/.paw/work/namespaced-skill-install/reviews/REVIEW-ARCHITECTURE.md
@@ -1,0 +1,154 @@
+# Architecture Review: Namespaced Skill Installation
+
+**Reviewer**: Architecture Specialist  
+**Date**: 2026-03-09  
+**Target**: Namespaced skill install feature diff  
+
+## Summary
+
+This review examines the architectural implications of introducing composite keys for skill namespacing. The changes eliminate cross-dependency skill name collisions by embedding namespace prefixes (`host/owner/repo`) directly in map keys, leveraging `filepath.Join` for directory creation. While functionally sound, the design introduces several architectural concerns around abstraction leakage and responsibility boundaries.
+
+## Findings
+
+### Finding: Composite key approach leaks path structure into business logic domains
+
+**Severity**: should-fix  
+**Confidence**: HIGH  
+**Category**: architecture  
+
+#### Grounds (Evidence)
+
+In `/tmp/review-diff.txt:29`, `collectSkillFiles()` creates composite keys using `compositeKey := prefix + "/" + skillName` where `prefix` is `parsed.PackageIdentity()`. These keys like `"github.com/org/repo/skillname"` are then used throughout the system:
+- In test expectations at line 74: `skills["github.com/org/repo/lint"]`
+- In `verifyIntegrity()` at line 320: `compositeKey := prefix + "/" + skillName`
+- In `Install()` function signature documentation at line 372: "composite key (host/owner/repo/skill-name)"
+
+The original codebase uses simple skill names as keys (`skills["lint"]`) in business logic, while filesystem paths are handled by the `Install()` function. The new design embeds filesystem structure (`/` separators, path ordering) directly in the business logic map keys.
+
+#### Warrant (Rule)
+
+This violates the abstraction principle that business logic should be independent of storage implementation details. The existing pattern keeps skill identification (business concern) separate from skill installation paths (storage concern). The composite key approach couples these domains by encoding filesystem path structure in business identifiers.
+
+When a map key contains path separators and relies on `filepath.Join` behavior for its meaning, the map has become a filesystem abstraction rather than a skill registry. Business logic that processes skills now must understand that keys are actually path fragments. This makes the code harder to reason about and creates implicit dependencies on filesystem path conventions.
+
+The existing codebase demonstrates a cleaner separation: `collectSkillFiles()` builds a skill registry (skill name → files), and `Install()` handles path construction. The new design conflates these concerns.
+
+#### Rebuttal Conditions
+
+This is NOT a concern if: (1) the composite key serves purposes beyond filesystem organization (e.g., skill lookup by package identity); or (2) the `Install()` function signature was already designed to accept path-like keys (examine the original design intent); or (3) there's a documented architectural decision to merge skill identity with installation paths for simplicity.
+
+#### Suggested Verification
+
+Consider introducing a dedicated `SkillRef` or `NamespacedSkillName` type that encapsulates the composite key logic and provides methods like `String()`, `InstallPath()`, and `SkillName()`. This would preserve the namespace functionality while maintaining abstraction boundaries.
+
+---
+
+### Finding: Removal of detectCollisions leaves architectural gap in dependency validation
+
+**Severity**: consider  
+**Confidence**: MEDIUM  
+**Category**: architecture  
+
+#### Grounds (Evidence)
+
+In `/tmp/review-diff.txt:443-468`, the `detectCollisions()` function is completely removed from `resolver.go`. The original function checked for duplicate skill names across resolved dependencies and returned clear error messages like `"skill name collision: %q is exported by both %s (commit %s) and %s (commit %s)"`. 
+
+The test at line 481 shows the original expectation: `TestResolveCollision` expected collision errors, but is renamed to `TestResolveSameNameSkillsAllowed` and now expects success. No replacement validation logic appears in the diff.
+
+#### Warrant (Rule)
+
+The resolver's responsibility includes dependency graph validation and conflict detection. While skill name conflicts are now resolved through namespacing, the complete removal of collision detection eliminates an entire class of validation that was providing valuable feedback to users.
+
+The original collision detection served a user experience purpose: it informed users when their dependency choices created naming conflicts and required resolution. With namespacing, users may not realize they have two skills with identical names until they attempt to use them, creating a delayed discovery problem.
+
+However, this is a borderline concern because the collision detection may have been purely prohibitive (blocking valid use cases) rather than informational. The architectural question is whether some form of conflict awareness should be preserved, even if it doesn't block resolution.
+
+#### Rebuttal Conditions
+
+This is NOT a concern if: (1) user tooling will provide skill discovery that makes name conflicts obvious; or (2) the collision detection was intended to be temporary until namespacing was implemented; or (3) the pinfile or installation logs provide sufficient visibility into installed skills that naming conflicts are readily apparent to users.
+
+#### Suggested Verification
+
+Check if there's a deliberate architectural decision to remove all collision detection, or if warnings (rather than errors) should be preserved to inform users about naming conflicts without blocking installation.
+
+---
+
+### Finding: Install function contract ambiguity around composite key directory creation
+
+**Severity**: consider  
+**Confidence**: MEDIUM  
+**Category**: architecture  
+
+#### Grounds (Evidence)
+
+In `/tmp/review-diff.txt:372-377`, the `Install()` function documentation states: "Each entry in skills maps a composite key (host/owner/repo/skill-name) to a map of relative file paths to contents. The composite key naturally creates nested directories via filepath.Join."
+
+The actual implementation in `/home/erdemtuna/workspace/personal/craft/internal/install/installer.go:28` shows: `skillDir := filepath.Join(target, skillName)` where `skillName` is now the composite key. This "naturally creates nested directories" through string concatenation rather than explicit directory structure management.
+
+The original function operated on simple skill names, with clear expectations about creating `<target>/<skill-name>/` directories. The new contract implies that any slash-containing string passed as a skill name will create nested directories.
+
+#### Warrant (Rule)
+
+Function contracts should be explicit about their behavior, especially when they change from simple to complex directory creation. The "naturally creates" phrasing suggests implicit behavior that callers must understand rather than explicit interface guarantees.
+
+The architectural concern is that `Install()` now implicitly supports arbitrary directory nesting based on input string content, but this capability isn't reflected in its signature or error handling. A caller could pass `"malicious/../../escape"` as a skill name and rely on existing path traversal checks rather than explicit directory depth validation.
+
+This is not necessarily a security issue (path traversal checks exist), but it represents an implicit contract change that could be made more explicit.
+
+#### Rebuttal Conditions
+
+This is NOT a concern if: (1) the `Install()` function was always designed to handle path-like skill names (check git history); or (2) the path traversal validation is sufficient to handle all edge cases of nested directory creation; or (3) the composite key format is guaranteed to be safe by the caller (e.g., always from `ParseDepURL`).
+
+#### Suggested Verification
+
+Consider making the directory nesting behavior explicit in the function signature (e.g., `InstallNested()`) or adding validation that composite keys conform to expected patterns. Review whether the path traversal checks are sufficient for the new nesting depth.
+
+---
+
+### Finding: Responsibility split between collectSkillFiles and Install creates coupling through composite keys
+
+**Severity**: consider  
+**Confidence**: HIGH  
+**Category**: architecture  
+
+#### Grounds (Evidence)
+
+In `/tmp/review-diff.txt:258` and `/tmp/review-diff.txt:288`, `collectSkillFiles()` constructs composite keys using `prefix := parsed.PackageIdentity()` and `compositeKey := prefix + "/" + skillName`. The `Install()` function at line 28 in `/home/erdemtuna/workspace/personal/craft/internal/install/installer.go` receives these keys and uses `filepath.Join(target, skillName)` to create the directory structure.
+
+This creates an implicit coupling: `collectSkillFiles()` must construct keys in exactly the format that `Install()` expects for directory creation. The two functions are in different packages (`internal/cli` and `internal/install`) but are now coupled through the string format of composite keys.
+
+In the original design, `collectSkillFiles()` returned simple skill names, and `Install()` handled all path construction locally. The new design splits path construction responsibility across package boundaries.
+
+#### Warrant (Rule)
+
+Module boundaries should minimize coupling between packages. When one package must format strings in a specific way for another package to interpret them as filesystem paths, the packages are implicitly coupled through string format conventions.
+
+This coupling is fragile because changes to the composite key format in `collectSkillFiles()` could break directory creation in `Install()` without any compile-time safety. The two packages must maintain agreement on the string format but have no enforced interface for this coordination.
+
+The existing codebase follows a cleaner pattern where `Install()` is responsible for all path construction decisions, receiving only business-level identifiers (skill names) from callers.
+
+#### Rebuttal Conditions
+
+This is NOT a concern if: (1) the composite key format is standardized and unlikely to change (e.g., mirrors Go module paths exactly); or (2) there are tests that enforce the contract between the two functions; or (3) the coupling is accepted as a reasonable trade-off for implementation simplicity.
+
+#### Suggested Verification
+
+Examine test coverage for the interaction between `collectSkillFiles()` and `Install()` with various composite key formats. Consider whether the composite key format should be defined in a shared package or enforced through type safety.
+
+---
+
+## Recommendations
+
+1. **Consider introducing a NamespacedSkillID type** to encapsulate composite key logic and provide explicit methods for different representations (business identifier vs. filesystem path).
+
+2. **Document the architectural decision** to merge skill identification with installation paths, explaining why the abstraction trade-off was chosen.
+
+3. **Add integration tests** that verify the contract between `collectSkillFiles()` and `Install()` across edge cases like non-GitHub hosts and deeply nested paths.
+
+4. **Evaluate whether collision warnings** (not errors) should be preserved to maintain user awareness of naming conflicts.
+
+## Overall Assessment
+
+The namespaced installation feature successfully addresses the core requirement of eliminating skill name collisions. The composite key approach is pragmatic and leverages existing filesystem primitives effectively. However, the design introduces abstraction leakage that couples business logic with storage concerns. While not functionally problematic, this represents a departure from the cleaner separation of concerns in the original architecture.
+
+The changes are implementation-ready but would benefit from more explicit interfaces and stronger abstraction boundaries to maintain long-term maintainability.

--- a/.paw/work/namespaced-skill-install/reviews/REVIEW-CORRECTNESS.md
+++ b/.paw/work/namespaced-skill-install/reviews/REVIEW-CORRECTNESS.md
@@ -1,0 +1,95 @@
+# Correctness Review — Namespaced Skill Installation
+
+Scope: Reviewed diff in `/tmp/review-diff.txt` against spec at `.paw/work/namespaced-skill-install/Spec.md` (esp. P2/FR-003). Focus is logic/spec fidelity for namespacing, integrity verification, and removal cleanup.
+
+---
+
+### Finding: `craft remove` orphan detection is still keyed only by skill *name*, so removing one of two deps with the same skill name will incorrectly skip deleting the removed dep’s namespaced skill directory
+
+**Severity**: must-fix  
+**Confidence**: HIGH  
+**Category**: correctness
+
+#### Grounds (Evidence)
+- Spec requires same-name skills from different deps to coexist and removal to delete only the removed dependency’s skill (Spec.md:36-44).
+- `internal/cli/remove.go:80-105` builds `remainingSkills` as `map[string]bool` keyed by **skill name** only, and computes `orphaned` by checking `if !remainingSkills[s]`.
+- With namespacing, two deps can both provide `skill-creator`, but they are installed in different paths. However, the current logic treats `skill-creator` as “still needed” if *any* remaining dep provides the same name, so the removed dep’s copy won’t be considered orphaned and won’t be removed.
+- The new comment in `internal/cli/remove_test.go:338-347` explicitly notes this mismatch (“The orphan check still uses skill NAMES…”), which indicates the implementation does not meet the P2 acceptance scenario.
+
+#### Warrant (Rule)
+When installation paths are namespaced by `host/owner/repo`, the “is this skill still needed?” question must be answered at least at the granularity of dependency identity (or namespaced path), not only by skill name. Otherwise, the remove operation can produce a semantically wrong result: leaving behind the removed dep’s installed artifacts.
+
+#### Rebuttal Conditions
+This is not a concern only if `craft remove` is intentionally defined to *never* delete a skill directory when another dependency has a same-named skill (even if it lives at a different namespaced path). That would contradict Spec.md P2/FR-003, so it would require a spec change.
+
+#### Suggested Verification
+Add an integration test: install two deps that both export `skill-creator`, remove one alias, and assert that `<target>/<removed-host>/<removed-owner>/<removed-repo>/skill-creator/` is gone while the other dep’s namespaced path remains. Also ensure removing an alias that still points to the same depURL doesn’t uninstall the dep.
+
+---
+
+### Finding: `craft remove` may remove empty namespace directories under *other* install targets even when no skill was removed from that target
+
+**Severity**: should-fix  
+**Confidence**: MEDIUM  
+**Category**: correctness
+
+#### Grounds (Evidence)
+- In `internal/cli/remove.go:123-158`, the `removed` flag is declared per-skill, then iterates `for _, tp := range targetPath`.
+- If the skill is removed from the first target, `removed` stays `true` for subsequent targets. The cleanup block `if removed && nsPrefix != "" { cleanEmptyParents(tp, filepath.Dir(skillDir)) }` (`internal/cli/remove.go:154-157`) can then run for a `tp` where the skill directory did not exist and nothing was removed.
+
+#### Warrant (Rule)
+Cleanup actions should be causally tied to the mutation they are meant to clean up. Running “remove empty parents” on a target where no directory was removed can delete empty directories that are unrelated to this operation (even if the deletion is constrained to “empty only”).
+
+#### Rebuttal Conditions
+Not a concern if (a) `targetPath` is always length 1 in practice, or (b) it is acceptable to opportunistically prune empty namespace directories under all targets whenever a dep is removed from any target.
+
+#### Suggested Verification
+If multiple targets are supported (multi-agent “Both”), add a test where only one target contains the removed dep’s namespaced dir and the other target contains an intentionally-empty namespace dir; verify it is not removed.
+
+---
+
+### Finding: `verifyIntegrity` now silently skips integrity verification for a dependency if `ParseDepURL` fails, weakening the “integrity must be checked” contract
+
+**Severity**: should-fix  
+**Confidence**: HIGH  
+**Category**: correctness
+
+#### Grounds (Evidence)
+- `internal/cli/install.go:306-309`:
+  ```go
+  parsed, err := resolve.ParseDepURL(dep.URL)
+  if err != nil {
+      continue
+  }
+  ```
+- This causes an entire dependency’s integrity check to be skipped if parsing fails, even when a pinfile integrity digest exists (`internal/cli/install.go:301-304`).
+
+#### Warrant (Rule)
+`verifyIntegrity` is explicitly described as preventing cache corruption/poisoning (internal/cli/install.go:296-299). Skipping verification on an unexpected-but-possible error path means the function can return success even when it failed to verify the intended property.
+
+#### Rebuttal Conditions
+Not a concern if it is provably impossible for any `dep.URL` in `result.Resolved` to fail `ParseDepURL` (i.e., a hard invariant enforced by the resolver and pinfile parser). In that case, this `continue` is dead code; otherwise it is a silent correctness gap.
+
+#### Suggested Verification
+Make `ParseDepURL` failures in this loop a hard error (or at least surface a warning + fail). Add a unit test that constructs a `ResolveResult` with an unparseable `dep.URL` and asserts that `verifyIntegrity` fails rather than silently succeeding.
+
+---
+
+### Finding: Composite key naming (`host/owner/repo/skillName`) is used as an OS path component; correctness depends on `PackageIdentity()` normalization being identical across install/remove/integrity
+
+**Severity**: consider  
+**Confidence**: MEDIUM  
+**Category**: correctness
+
+#### Grounds (Evidence)
+- `internal/cli/install.go:257-290` uses `prefix := parsed.PackageIdentity()` and `compositeKey := prefix + "/" + skillName`.
+- `internal/cli/remove.go:115-131` also uses `parsed.PackageIdentity()` for `nsPrefix` to construct the cleanup directory.
+
+#### Warrant (Rule)
+If `PackageIdentity()` normalization differs depending on how the URL is spelled (e.g., case differences, `.git` suffix, scheme vs no scheme), then the computed namespace may differ between installation and removal/integrity reconstruction, leading to orphaned directories or mismatched integrity computation.
+
+#### Rebuttal Conditions
+Not a concern if `ParseDepURL` canonicalizes identity strictly and all stored `depURL` strings (manifest + pinfile) are already normalized/canonical.
+
+#### Suggested Verification
+Add tests that install from different equivalent URL spellings (if supported) and confirm the namespace path is identical; also ensure remove uses the exact same canonical identity.

--- a/.paw/work/namespaced-skill-install/reviews/REVIEW-EDGE-CASES.md
+++ b/.paw/work/namespaced-skill-install/reviews/REVIEW-EDGE-CASES.md
@@ -1,0 +1,248 @@
+# Edge Cases Review — Namespaced Skill Installation
+
+**Reviewer**: Edge Cases Specialist
+**Scope**: Boundary analysis of namespaced skill install/remove changes
+**Diff**: `internal/cli/install.go`, `internal/cli/remove.go`, `internal/resolve/resolver.go`, `internal/install/installer.go` and associated tests
+
+---
+
+## Boundary Categories Checked
+
+For each code path modified in this diff, the following boundary categories were analyzed:
+
+| Category | install.go collectSkillFiles | install.go verifyIntegrity | remove.go runRemove | remove.go cleanEmptyParents |
+|---|---|---|---|---|
+| Null/empty input | ✅ checked | ✅ checked | ❌ **finding** | ✅ checked |
+| Partial failure | ✅ handled | ⚠️ **finding** | ❌ **finding** | ✅ handled |
+| Duplicate/collision | ✅ handled by design | ✅ handled | ❌ **finding** | N/A |
+| Interrupted operation | ✅ staging swap | ✅ read-only | ✅ RemoveAll is atomic | ✅ idempotent |
+| Concurrent access | ✅ staging swap | ✅ read-only | ⚠️ acceptable | ⚠️ acceptable |
+| Maximum values | ✅ no new limits | ✅ no new limits | ✅ no new limits | ✅ bounded by depth |
+| Symlinks | N/A | N/A | N/A | ⚠️ **finding** |
+
+---
+
+### Finding: Orphan detection uses bare skill names but cleanup uses namespaced paths — shared-name skills are never cleaned up
+
+**Severity**: must-fix
+**Confidence**: HIGH
+**Category**: edge-cases
+
+#### Grounds (Evidence)
+
+In `internal/cli/remove.go:80-104`, the orphan detection logic builds `remainingSkills` from pinfile `entry.Skills`, which contains **bare skill names** (e.g., `"skill-creator"`):
+
+```go
+// remove.go:81-87
+remainingSkills := make(map[string]bool)
+for _, remainingURL := range m.Dependencies {
+    if entry, ok := pf.Resolved[remainingURL]; ok {
+        for _, s := range entry.Skills {
+            remainingSkills[s] = true  // bare name: "skill-creator"
+        }
+    }
+}
+```
+
+The orphaned check at lines 99-104 compares bare names:
+
+```go
+for _, s := range removedSkills {
+    if !remainingSkills[s] {  // "skill-creator" IS in remainingSkills from dep-b
+        orphaned = append(orphaned, s)
+    }
+}
+```
+
+But cleanup at lines 126-129 uses namespaced paths:
+
+```go
+if nsPrefix != "" {
+    skillDir = filepath.Join(tp, nsPrefix, skillName)  // target/github.com/org/a/skill-creator
+}
+```
+
+**Concrete scenario**: dep-a (`github.com/org/a@v1.0.0`) and dep-b (`github.com/org/b@v1.0.0`) both export `"skill-creator"`. Skills are installed at:
+- `target/github.com/org/a/skill-creator/`
+- `target/github.com/org/b/skill-creator/`
+
+When the user runs `craft remove dep-a`, `"skill-creator"` is in `remainingSkills` (from dep-b), so it is NOT added to `orphaned`. dep-a's `github.com/org/a/skill-creator/` directory is **never cleaned up**. The empty parent directories `github.com/org/a/` also remain.
+
+The test at `internal/cli/remove_test.go:180-184` acknowledges this with a comment but does not assert that dep-a's shared-skill IS removed — it only checks that `unique-a` is removed.
+
+#### Warrant (Rule)
+
+With namespaced paths, skills from different deps are **independent on disk** even when they share a name. The entire premise of this PR is that `github.com/org/a/skill-creator` and `github.com/org/b/skill-creator` are distinct paths that don't collide. The orphan detection must reflect this: when dep-a is removed, **all** of dep-a's skills should be cleaned up regardless of whether another dep exports the same bare name, because the disk paths are different. The current bare-name comparison is a holdover from the flat-path layout where same-name skills truly occupied the same path.
+
+#### Rebuttal Conditions
+
+This is NOT a concern if: (1) the pinfile `Skills` field stores namespaced names rather than bare names — but `pinfile/types.go:32` shows it stores bare names; or (2) the design intentionally retains dep-a's files when dep-b shares a name — but this contradicts the spec at Spec.md line 43-44 ("only that dependency's skills to be cleaned up") and leaves unreachable files on disk.
+
+#### Suggested Verification
+
+Fix: With namespacing, the `remainingSkills` check for same-name retention is no longer necessary for disk cleanup. Every skill from the removed dep should be treated as orphaned because its disk path (`nsPrefix/skillName`) is unique to that dep. Simplify: replace the orphaned detection with `orphaned = removedSkills` (all skills from the removed dep are orphaned). Alternatively, make `remainingSkills` use composite keys `(depURL, skillName)` instead of bare names. Add a test that removes dep-a when dep-b exports the same skill name, and assert dep-a's namespaced directory IS deleted.
+
+---
+
+### Finding: ParseDepURL failure in remove.go silently skips cleanup — files installed at namespaced paths become unreachable
+
+**Severity**: should-fix
+**Confidence**: MEDIUM
+**Category**: edge-cases
+
+#### Grounds (Evidence)
+
+In `internal/cli/remove.go:115-120`:
+
+```go
+parsed, parseErr := resolve.ParseDepURL(depURL)
+var nsPrefix string
+if parseErr == nil {
+    nsPrefix = parsed.PackageIdentity()
+}
+```
+
+If `ParseDepURL` fails, `nsPrefix` remains `""`, and cleanup falls through to the flat path at line 131: `skillDir = filepath.Join(tp, skillName)`. But skills were **installed** under namespaced paths (e.g., `target/github.com/org/repo/skill-creator/`). The flat path `target/skill-creator/` doesn't exist, `os.Stat` at line 146 returns an error, and the skill is silently not removed.
+
+Meanwhile, in `collectSkillFiles` (install.go:252-254), `ParseDepURL` failure is a hard error that aborts installation. This asymmetry means: if a dep URL somehow fails to parse during remove but succeeded during install, the namespaced files are orphaned with no warning to the user.
+
+#### Warrant (Rule)
+
+Every input has an implicit boundary. The `depURL` value comes from `m.Dependencies[alias]` which was written by the user in `craft.yaml`. While `ParseDepURL` should succeed for any URL that was successfully installed, defensive code should not silently degrade to a wrong path. The `continue` on parse failure would produce a confusing user experience: "cleaned up 0 orphaned skills" while files remain on disk.
+
+#### Rebuttal Conditions
+
+This is NOT a concern if: (1) `ParseDepURL` is guaranteed to succeed for any URL in a valid manifest — but the manifest schema only validates URL format loosely; or (2) the code logs a warning on parse failure — but it currently does not.
+
+#### Suggested Verification
+
+Add a warning when `ParseDepURL` fails in remove.go: `cmd.PrintErrf("warning: could not parse dep URL %q for cleanup: %v\n", depURL, parseErr)`. Alternatively, return an error since a URL that was valid during install should always be valid during remove.
+
+---
+
+### Finding: verifyIntegrity silently skips integrity checking when ParseDepURL fails — cache corruption bypasses detection
+
+**Severity**: should-fix
+**Confidence**: MEDIUM
+**Category**: edge-cases
+
+#### Grounds (Evidence)
+
+In `internal/cli/install.go:306-309`:
+
+```go
+parsed, err := resolve.ParseDepURL(dep.URL)
+if err != nil {
+    continue  // silently skip integrity check for this dep
+}
+```
+
+If `ParseDepURL` fails, the entire integrity verification for that dependency is skipped without error or warning. A tampered or corrupted dependency would bypass the integrity check.
+
+In contrast, `collectSkillFiles` at line 252-254 treats `ParseDepURL` failure as a hard error. The inconsistency means: if `collectSkillFiles` succeeds, `verifyIntegrity` should also be able to parse the same URLs. But the silent `continue` masks any logic errors that might cause the two functions to diverge.
+
+#### Warrant (Rule)
+
+Integrity verification is a security boundary. Silent skipping on any condition that isn't a clear "this dep doesn't need checking" weakens the guarantee. The existing `continue` for missing pinfile entries (line 302) is appropriate — those deps genuinely don't have digests. But `ParseDepURL` failure is an unexpected condition that should surface.
+
+#### Rebuttal Conditions
+
+This is NOT a concern if: `collectSkillFiles` always runs before `verifyIntegrity` (it does — line 107 vs 113 in `runInstall`), and both use the same `dep.URL` values from the same `result.Resolved` slice. In practice, a parse failure in verify implies one already occurred in collect, which would have aborted. The risk is theoretical but the silent skip is fragile.
+
+#### Suggested Verification
+
+Change the `continue` to return an error: `return fmt.Errorf("verifying integrity for %s: %w", dep.URL, err)`. This maintains the principle that unexpected conditions in integrity checking should surface, not hide.
+
+---
+
+### Finding: cleanEmptyParents uses filepath.Abs (not EvalSymlinks) — symlinked intermediate directories could be removed
+
+**Severity**: consider
+**Confidence**: LOW
+**Category**: edge-cases
+
+#### Grounds (Evidence)
+
+In `internal/cli/remove.go:175-190`, `cleanEmptyParents` uses `filepath.Abs` for the boundary check:
+
+```go
+absDir, err := filepath.Abs(dir)
+if err != nil || absDir == absRoot || !strings.HasPrefix(absDir, absRoot+string(filepath.Separator)) {
+    break
+}
+if err := os.Remove(dir); err != nil {
+    break
+}
+```
+
+`filepath.Abs` does **not** resolve symlinks (only `filepath.EvalSymlinks` does). If an intermediate directory in the namespace path (e.g., `github.com/org/`) is a symlink, `os.Remove` removes the symlink itself rather than the target directory. The `HasPrefix` check compares lexical paths, so a symlink whose target is outside the root would still pass if the symlink's name is under root.
+
+#### Warrant (Rule)
+
+In practice, symlinks in the install target directory tree are unlikely — craft creates these directories itself via `os.MkdirAll`. However, `os.Remove` on a symlink to a non-empty directory would succeed (removing the symlink), potentially orphaning the target's contents. The blast radius is low: only craft-managed directories under the install target are affected.
+
+#### Rebuttal Conditions
+
+This is NOT a concern if: (1) no symlinks exist in the install target tree — craft creates real directories, and nothing in the workflow creates symlinks there; or (2) the `os.Remove` failure on non-empty directories already provides safety — `os.Remove` fails on non-empty real directories but succeeds on symlinks regardless of target contents.
+
+#### Suggested Verification
+
+No code change needed for the common case. If symlink safety is desired in the future, use `filepath.EvalSymlinks` and check that the resolved path is still under the resolved root before removing. Low priority given current usage.
+
+---
+
+### Finding: Dep exporting zero skills — no namespace directory created (handled correctly)
+
+**Severity**: N/A (no issue found)
+**Confidence**: HIGH
+**Category**: edge-cases
+
+#### Examination Summary
+
+In `internal/cli/install.go:266`, the `for i, skillName := range dep.Skills` loop body is never entered when `dep.Skills` is empty. No composite key is inserted into the `skills` map, no namespace directory is created by `installer.go`, and no empty directory cleanup is needed. The same applies in `verifyIntegrity` — the `combined` map stays empty and produces a valid (deterministic) digest. The zero-skills case is handled correctly by the absence of iteration.
+
+---
+
+### Finding: Two dep URLs with the same PackageIdentity at different versions — MVS prevents this, but verify the assumption
+
+**Severity**: consider
+**Confidence**: MEDIUM
+**Category**: edge-cases
+
+#### Grounds (Evidence)
+
+In `internal/cli/install.go:288`:
+
+```go
+compositeKey := prefix + "/" + skillName
+skills[compositeKey] = files
+```
+
+If two entries in `result.Resolved` have the same `PackageIdentity()` (e.g., `github.com/org/repo` at v1.0.0 and v2.0.0) and export the same skill name, the second iteration **silently overwrites** the first in the `skills` map. There is no error or warning.
+
+The resolver at `internal/resolve/resolver.go` uses MVS (Minimum Version Selection) which should reduce same-package deps to a single version. But transitive dependency resolution could theoretically produce two entries for the same package identity if MVS has a bug or if the `ResolvedDep` list contains duplicates.
+
+#### Warrant (Rule)
+
+Map key collision with silent overwrite is a latent data-loss pattern. The current code assumes `result.Resolved` never contains two entries with the same `PackageIdentity()` + skill name. This assumption is valid given MVS but is not enforced at this layer.
+
+#### Rebuttal Conditions
+
+This is NOT a concern if: (1) MVS is correctly implemented and guarantees at most one version per `PackageIdentity()` in the resolved set — which appears to be the case; or (2) a pre-existing validation in the resolver prevents duplicates.
+
+#### Suggested Verification
+
+Add a defensive check: if `compositeKey` already exists in the `skills` map when inserting, log a warning or return an error. This costs one map lookup and catches resolver bugs early. Low priority given MVS guarantees.
+
+---
+
+## Summary
+
+| # | Finding | Severity | Confidence |
+|---|---------|----------|------------|
+| 1 | Orphan detection uses bare names — shared-name skills never cleaned up | must-fix | HIGH |
+| 2 | ParseDepURL failure in remove.go silently skips cleanup | should-fix | MEDIUM |
+| 3 | verifyIntegrity silently skips on ParseDepURL failure | should-fix | MEDIUM |
+| 4 | cleanEmptyParents doesn't resolve symlinks | consider | LOW |
+| 5 | Zero-skill deps handled correctly | N/A | HIGH |
+| 6 | Same PackageIdentity collision — silent map overwrite | consider | MEDIUM |

--- a/.paw/work/namespaced-skill-install/reviews/REVIEW-SECURITY.md
+++ b/.paw/work/namespaced-skill-install/reviews/REVIEW-SECURITY.md
@@ -1,0 +1,88 @@
+# Security Review: Namespaced Skill Installation
+
+## Examination Summary
+I analyzed the changes in `internal/cli/install.go`, `internal/cli/remove.go`, and `internal/install/installer.go` focusing on path traversal, filesystem integrity, and cleanup logic. The introduction of composite keys (`host/owner/repo/skill`) and the removal of collision detection were evaluated for security implications. The core path traversal protections in `Install` appear robust even with deeper nesting, as they rely on `filepath.Abs` and prefix checking against the target root. However, I identified two significant issues regarding data cleanup and potential filesystem collisions.
+
+## Findings
+
+### Finding: Stale code persistence due to incomplete cleanup on removal
+
+**Severity**: should-fix
+**Confidence**: HIGH
+**Category**: security
+
+#### Grounds (Evidence)
+In `internal/cli/remove.go`, the `runRemove` function identifies orphaned skills using logic from the old flat-layout era:
+```go
+// Find orphaned skills (only in removed dep, not in any remaining dep)
+var orphaned []string
+for _, s := range removedSkills {
+    if !remainingSkills[s] {
+        orphaned = append(orphaned, s)
+    }
+}
+```
+This logic explicitly skips removal of a skill if *any other* dependency exports a skill with the same name (`if !remainingSkills[s]`).
+
+#### Warrant (Rule)
+In the new namespaced architecture, skills are **never** shared on disk. Dependency A installs to `.../DepA/skill` and Dependency B installs to `.../DepB/skill`. If the user removes Dependency A, `.../DepA/skill` must be deleted. The current logic incorrectly preserves `.../DepA/skill` if Dependency B also has a skill with the same name.
+From a security perspective, "removing" a dependency must remove its code. If Dependency A is removed because it contains a vulnerability, this bug preserves the vulnerable code on disk (orphaned in `.../DepA/skill`) simply because Dependency B has a similarly-named skill. Tools scanning the install directory may still execute or bundle the vulnerable code.
+
+#### Rebuttal Conditions
+This would not be a security concern if the installation layout was still flat (shared directories), where reference counting would be required. However, the spec confirms the layout is now fully namespaced.
+
+#### Suggested Verification
+1. Install two dependencies (DepA, DepB) that both export `common-skill`.
+2. Verify both exist on disk at their namespaced paths.
+3. Run `craft remove DepA`.
+4. Verify that `.../DepA/common-skill` still exists on disk (it should have been removed).
+
+---
+
+### Finding: Filesystem corruption via collision of same-repo/mixed-version dependencies
+
+**Severity**: consider
+**Confidence**: MEDIUM
+**Category**: security
+
+#### Grounds (Evidence)
+The namespacing strategy uses `parsed.PackageIdentity()` (Host/Owner/Repo) as the directory prefix in `internal/cli/install.go`:
+```go
+prefix := parsed.PackageIdentity()
+// ...
+compositeKey := prefix + "/" + skillName
+```
+If the resolver allows the same repository to be included twice (e.g., via different aliases, or `https` vs `ssh` URLs) at *different versions*, they will map to the exact same directory structure `target/host/owner/repo/...`.
+
+#### Warrant (Rule)
+The removal of `detectCollisions` (FR-002) allows overlapping skills. However, without a collision detector or a version/alias discriminator in the path, two versions of the same repo will overwrite each other's files in a non-deterministic order (Last Write Wins during map iteration). This violates integrity: the on-disk state will be a corrupted mix of Version A and Version B files, or silently Version B when the user expects Version A for that alias.
+
+#### Rebuttal Conditions
+This is not a concern if the Resolver explicitly enforces a "Singleton Repo" rule (one version per repo identity globally), preventing the Diamond Dependency problem. If `craft` allows multiple versions of the same lib (like NPM), then this is a bug. Given `detectCollisions` was removed, the system is now more permissive, increasing the likelihood of this clash.
+
+#### Suggested Verification
+Add a test case with two dependencies pointing to the same git repo but different commits, using different aliases. Run install. Check if the files in `target/host/owner/repo` correspond to only one commit or a mix, and if the user is warned.
+
+---
+
+### Finding: `cleanEmptyParents` is safe but relies on strict usage
+
+**Severity**: consider
+**Confidence**: HIGH
+**Category**: security
+
+#### Grounds (Evidence)
+In `internal/cli/remove.go`, `cleanEmptyParents` walks up the directory tree:
+```go
+for {
+    absDir, err := filepath.Abs(dir)
+    if err != nil || absDir == absRoot || !strings.HasPrefix(absDir, absRoot+string(filepath.Separator)) {
+        break
+    }
+    if err := os.Remove(dir); err != nil { break }
+    dir = filepath.Dir(dir)
+}
+```
+
+#### Warrant (Rule)
+This implementation is secure. It explicitly checks `!strings.HasPrefix` to ensure it never deletes directories outside the target root, and `absDir == absRoot` ensures it doesn't delete the root itself. It uses `os.Remove` (not `RemoveAll`), which guarantees only empty directories are removed. This finding confirms the safety of this sensitive operation, as requested in the review instructions.

--- a/.paw/work/namespaced-skill-install/reviews/REVIEW-TESTING.md
+++ b/.paw/work/namespaced-skill-install/reviews/REVIEW-TESTING.md
@@ -1,0 +1,476 @@
+# Testing Specialist Review: Namespaced Skill Installation
+
+**Specialist**: Testing  
+**Review Date**: 2026-03-09  
+**Confidence**: HIGH
+
+## Executive Summary
+
+This review analyzes the test coverage for the namespaced skill installation feature. The change namespaces installed skills by host/owner/repo to allow same-name skills from different dependencies. From a testing perspective, the implementation introduces several high-risk scenarios that lack adequate test coverage, particularly around error handling paths and the new `cleanEmptyParents()` function. The existing test suite has been updated for the new namespaced paths, but several gaps remain that could allow production regressions.
+
+**Highest Priority Concerns**:
+1. No tests for `cleanEmptyParents()` function — this recursive directory cleanup logic is untested
+2. `verifyIntegrity()` error path (ParseDepURL failure) is untested
+3. Non-GitHub hosts (GitLab, Bitbucket, self-hosted) are untested despite being in scope
+4. `TestRunRemove_SharedSkillRetained` was simplified and may no longer verify the right behavior with namespacing
+
+---
+
+## Findings
+
+### Finding: cleanEmptyParents function has no tests despite handling recursive directory deletion
+
+**Severity**: must-fix  
+**Confidence**: HIGH  
+**Category**: testing
+
+#### Grounds (Evidence)
+
+In `internal/cli/remove.go:265-282`, the new `cleanEmptyParents()` function was introduced:
+
+```go
+func cleanEmptyParents(root, dir string) {
+    absRoot, err := filepath.Abs(root)
+    if err != nil {
+        return
+    }
+    for {
+        absDir, err := filepath.Abs(dir)
+        if err != nil || absDir == absRoot || !strings.HasPrefix(absDir, absRoot+string(filepath.Separator)) {
+            break
+        }
+        if err := os.Remove(dir); err != nil {
+            break // not empty or permission error
+        }
+        dir = filepath.Dir(dir)
+    }
+}
+```
+
+This function performs recursive directory cleanup, walking up the directory tree and removing empty parent directories. It has complex boundary conditions:
+- Stops at the root boundary
+- Handles filepath.Abs errors
+- Handles os.Remove errors (non-empty dirs, permissions)
+- Uses string prefix matching for security
+
+Despite this complexity, there are **zero tests** in `internal/cli/remove_test.go` that directly exercise this function. The closest test is `TestRunRemove_ExistingDep` (line 82-89 of remove_test.go), which verifies that `github.com/org/repo` is cleaned up, but this is an indirect check buried in an integration test — not a focused unit test of the cleanup logic.
+
+#### Warrant (Rule)
+
+Recursive directory deletion is one of the highest-risk operations in a package manager. Off-by-one errors in boundary conditions could cause:
+1. Deleting too much (removing root or parent directories outside the target)
+2. Deleting too little (leaving empty directories that accumulate over time)
+3. Infinite loops (if `filepath.Dir` doesn't eventually reach root)
+4. Path traversal vulnerabilities (if prefix check is incorrect)
+
+The test at line 87-89 of `remove_test.go` checks that `github.com/org/repo` is gone, but it doesn't verify:
+- What happens when `root` and `dir` are equal (should stop immediately)
+- What happens when `dir` is already outside `root` (should not delete anything)
+- What happens when a parent dir is non-empty (should stop at that level)
+- What happens when `filepath.Abs` fails (should return gracefully)
+- Whether it correctly stops before deleting `root` itself
+
+These are classic boundary conditions for recursive algorithms, and they're untested. If a bug is introduced (e.g., changing `absDir == absRoot` to `absDir != absRoot`), the existing tests might still pass while the function deletes the wrong directories.
+
+#### Rebuttal Conditions
+
+This is NOT a concern if: (1) the integration test at `TestRunRemove_ExistingDep` has sufficient assertions that would catch all realistic boundary bugs (verify: does it test non-empty parent dirs, root boundary, and prefix violations?); or (2) `cleanEmptyParents` is a trivial wrapper around a well-tested stdlib function (check: `os.Remove` is tested by stdlib, but the loop logic and boundary conditions are not).
+
+#### Suggested Verification
+
+Add unit tests for `cleanEmptyParents()` covering:
+1. **Normal case**: `root=/target`, `dir=/target/github.com/org/repo/skill` → removes `repo`, `org`, `github.com` if all empty
+2. **Stops at non-empty**: `root=/target`, `dir=/target/github.com/org/repo/skill` with sibling file in `/target/github.com/org/repo/other-skill` → removes only `skill`, stops at `repo`
+3. **Root boundary**: `root=/target`, `dir=/target` → removes nothing (stops immediately)
+4. **Already outside root**: `root=/target`, `dir=/outside` → removes nothing
+5. **Abs error handling**: Mock `filepath.Abs` to return error → function returns without panic
+6. **Remove error handling**: Create a non-empty dir in the chain → stops at that dir without error
+
+Mark these as unit tests (not integration tests) so they run fast and provide clear failure messages.
+
+---
+
+### Finding: verifyIntegrity() ParseDepURL error path is untested, allowing silent failures
+
+**Severity**: must-fix  
+**Confidence**: HIGH  
+**Category**: testing
+
+#### Grounds (Evidence)
+
+In `internal/cli/install.go:338-343` (diff lines 38-43), `verifyIntegrity()` now calls `ParseDepURL()` and silently continues on error:
+
+```go
+parsed, err := resolve.ParseDepURL(dep.URL)
+if err != nil {
+    continue
+}
+```
+
+This error path is **never exercised** in the test suite. In `internal/cli/install_test.go`, all three `verifyIntegrity` tests (`TestVerifyIntegrity_Pass`, `TestVerifyIntegrity_Mismatch`, `TestVerifyIntegrity_SkipsMissingPinEntry`) use well-formed URLs like `"github.com/org/repo@v1.0.0"`.
+
+There is no test with a malformed URL that would cause `ParseDepURL` to fail (e.g., `"not-a-valid-url"`, `"github.com/invalid"`, `""`). The existing test `TestCollectSkillFiles_SkipsBadDepURL` (line 153-173) tests the error path in `collectSkillFiles()`, but not in `verifyIntegrity()`.
+
+#### Warrant (Rule)
+
+The `continue` on line 340 means that if `ParseDepURL` fails for a resolved dependency, that dependency's integrity is **never checked**. This is a security-critical code path — integrity verification is the mechanism that prevents cache poisoning attacks. If a malformed URL causes the verification to be skipped, an attacker could potentially inject tampered skill files without detection.
+
+The behavioral contract for `verifyIntegrity()` should be: "for every resolved dependency, verify that the fetched files match the pinfile digest." The current implementation violates this contract silently when `ParseDepURL` fails. The tests don't verify this contract — they only verify that well-formed URLs are checked correctly.
+
+A realistic regression scenario: a future refactor changes the URL format in `ResolvedDep`, causing `ParseDepURL` to fail for all dependencies. The `verifyIntegrity()` function would skip all checks and return success, and all existing tests would pass because they don't assert what happens when parsing fails.
+
+#### Rebuttal Conditions
+
+This is NOT a concern if: (1) `ParseDepURL` is guaranteed to succeed for all URLs that make it into a `ResolvedDep` (check: are there validation steps earlier in the pipeline that reject malformed URLs?); or (2) the `continue` behavior is intentional and safe (e.g., if a URL can't be parsed, it's acceptable to skip verification for that dep). Verify the design intent.
+
+#### Suggested Verification
+
+Add test: `TestVerifyIntegrity_SkipsMalformedURL`. Set up:
+- Create a `ResolvedDep` with a malformed URL (e.g., `"not-a-valid-url"` from the existing test)
+- Provide skill files for that dep with tampered content
+- Provide a pinfile entry with a known-good digest
+
+Assert: `verifyIntegrity()` returns success (not error) because it skips the malformed dep. Then add a comment explaining whether this is the intended behavior or a silent failure. If it's a silent failure, change the code to return an error or log a warning.
+
+Alternative: If `ParseDepURL` failure is considered a bug (dependencies should never have malformed URLs), change the `continue` to `return fmt.Errorf("invalid dep URL: %w", err)` and update the test to expect an error.
+
+---
+
+### Finding: No tests for non-GitHub hosts despite being explicitly in scope
+
+**Severity**: must-fix  
+**Confidence**: HIGH  
+**Category**: testing
+
+#### Grounds (Evidence)
+
+The spec (`Spec.md:69`) explicitly lists non-GitHub hosts as an edge case:
+> "Non-GitHub hosts (GitLab, Bitbucket, self-hosted) produce valid namespace paths (e.g., `gitlab.com/org/repo/skill-name/`)."
+
+Success criterion SC-005 states:
+> "Skills from non-GitHub hosts install under the correct host-prefixed path."
+
+However, **zero tests** in the test suite use non-GitHub hosts. All test URLs use `github.com`:
+- `install_test.go`: `"github.com/org/repo"`, `"github.com/lossyrob/paw"`, `"github.com/anthropics/skills"`
+- `remove_test.go`: `"github.com/org/a"`, `"github.com/org/b"`, `"github.com/org/repo"`
+- `installer_test.go`: `"github.com/org/repo"`, `"github.com/other/tools"`
+
+The namespacing logic in `collectSkillFiles()` uses `parsed.PackageIdentity()` (line 9, diff), which is supposed to work for any git host. The spec says it's in scope and has a success criterion, but there's no test verifying that `gitlab.com/org/repo@v1.0.0` produces `<target>/gitlab.com/org/repo/skill/` instead of some mangled or incorrect path.
+
+#### Warrant (Rule)
+
+The highest-risk scenario for multi-host support is that the code works for GitHub but silently fails for other hosts. Common failure modes:
+1. **Hardcoded assumptions**: Code assumes "github.com" and breaks on other hosts
+2. **URL parsing differences**: GitLab/Bitbucket URLs might parse differently (e.g., `gitlab.com` vs `www.gitlab.com`, `git@gitlab.com:org/repo.git` vs `https://gitlab.com/org/repo.git`)
+3. **Path separator issues**: Some hosts might include extra segments (e.g., `gitlab.com/namespace/subgroup/project`)
+
+Without tests for non-GitHub hosts, the first time a user tries to install a skill from GitLab, it could fail in production. The spec explicitly scopes this as a requirement, but the tests don't verify it — meaning the spec and tests are out of sync.
+
+#### Rebuttal Conditions
+
+This is NOT a concern if: (1) the underlying `ParseDepURL()` function has its own comprehensive tests for multi-host parsing (check `internal/resolve/depurl_test.go`); AND (2) the integration between `ParseDepURL` and `collectSkillFiles`/`Install` is guaranteed to work for any valid host (verify: is there any GitHub-specific logic in the integration path?).
+
+#### Suggested Verification
+
+Add tests with non-GitHub hosts:
+1. `TestCollectSkillFiles_GitLabHost`: Use `"gitlab.com/org/repo@v1.0.0"` and verify the composite key is `"gitlab.com/org/repo/skill-name"` (not `"github.com/..."` or mangled)
+2. `TestInstallCompositeKeys_BitbucketHost`: Use `"bitbucket.org/user/project@v1.0.0"` and verify files install under `<target>/bitbucket.org/user/project/skill/`
+3. `TestRunRemove_SelfHostedGit`: Use `"code.internal.company.com/team/repo@v1.0.0"` and verify cleanup path is `<target>/code.internal.company.com/team/repo/skill/`
+
+These tests should be parallel to the existing GitHub tests, not in a separate "edge case" section — multi-host support is a first-class requirement, not an edge case.
+
+---
+
+### Finding: TestRunRemove_SharedSkillRetained was simplified and may no longer verify the intended behavior
+
+**Severity**: should-fix  
+**Confidence**: MEDIUM  
+**Category**: testing
+
+#### Grounds (Evidence)
+
+In `internal/cli/remove_test.go:128-188`, the test `TestRunRemove_SharedSkillRetained` was updated for namespaced paths. The test comment at line 180-184 now says:
+
+```go
+// shared-skill should be retained (dep-b still provides it)
+// Note: with namespacing, shared-skill from dep-a lives under github.com/org/a/
+// and dep-b's shared-skill would live under github.com/org/b/ — they're separate paths.
+// The orphan check still uses skill NAMES, but the disk paths are namespaced.
+// unique-a should be cleaned up since only dep-a provided it
+```
+
+The test setup (lines 163-164) creates only **one** skill directory on disk:
+```go
+_ = os.MkdirAll(filepath.Join(targetDir, "github.com", "org", "a", "shared-skill"), 0755)
+_ = os.MkdirAll(filepath.Join(targetDir, "github.com", "org", "a", "unique-a"), 0755)
+```
+
+Notice that `dep-b`'s `shared-skill` directory (`github.com/org/b/shared-skill`) is **not created**. The test comment says "shared-skill should be retained (dep-b still provides it)", but there's nothing to retain — `dep-b`'s shared-skill was never installed on disk.
+
+The original test (before the diff) likely had a non-namespaced `shared-skill/` directory that was shared by both deps. After removing `dep-a`, the test verified that the shared directory remained because `dep-b` still needed it. But with namespacing, the two `shared-skill` directories are separate (`a/shared-skill` and `b/shared-skill`), so there's nothing shared to retain.
+
+The test now only verifies that `unique-a` is removed (line 185-187), which is a trivial case — any skill from a removed dep should be deleted. It doesn't test the "shared skill retained" scenario anymore.
+
+#### Warrant (Rule)
+
+The test name is `TestRunRemove_SharedSkillRetained`, but it no longer tests that scenario. With namespacing, same-name skills from different deps occupy different disk paths, so the orphan check logic changed. The test should verify the **new** behavior:
+
+1. **Orphan check uses skill names** (not paths): When `dep-a` is removed, the orphan check looks at all remaining deps and sees if any still export `"shared-skill"`. If `dep-b` exports `"shared-skill"`, then `"shared-skill"` is not orphaned — but since the disk paths are namespaced, `dep-a`'s `shared-skill` directory (`a/shared-skill`) should still be deleted, while `dep-b`'s `shared-skill` directory (`b/shared-skill`) should remain untouched.
+
+2. **The test doesn't verify this**: It creates `dep-a`'s shared-skill but not `dep-b`'s. After removing `dep-a`, there's no `dep-b` directory to check if it was retained or incorrectly deleted.
+
+The test needs to be updated to reflect the new namespaced behavior, or renamed to reflect what it actually tests (e.g., `TestRunRemove_UniqueSkillDeleted`).
+
+#### Rebuttal Conditions
+
+This is NOT a concern if: (1) the test's original intent was to verify that the removal logic doesn't crash when multiple deps share a skill name, and the current test still verifies that (no crash, correct cleanup of removed dep); or (2) the orphan check is name-based but the cleanup is path-based, and the test correctly verifies that path-based cleanup works even when names overlap. Check the actual orphan logic in `remove.go` to confirm.
+
+#### Suggested Verification
+
+Option 1: Update the test to verify the full scenario:
+```go
+// Create both deps' shared-skill directories
+_ = os.MkdirAll(filepath.Join(targetDir, "github.com", "org", "a", "shared-skill"), 0755)
+_ = os.MkdirAll(filepath.Join(targetDir, "github.com", "org", "b", "shared-skill"), 0755)
+_ = os.MkdirAll(filepath.Join(targetDir, "github.com", "org", "a", "unique-a"), 0755)
+
+// After removing dep-a, verify:
+// - dep-a's shared-skill is GONE
+if _, err := os.Stat(filepath.Join(targetDir, "github.com", "org", "a", "shared-skill")); err == nil {
+    t.Error("dep-a's shared-skill should be removed")
+}
+// - dep-b's shared-skill is RETAINED
+if _, err := os.Stat(filepath.Join(targetDir, "github.com", "org", "b", "shared-skill")); err != nil {
+    t.Error("dep-b's shared-skill should be retained")
+}
+// - unique-a is GONE
+if _, err := os.Stat(filepath.Join(targetDir, "github.com", "org", "a", "unique-a")); err == nil {
+    t.Error("unique-a should be removed")
+}
+```
+
+Option 2: Rename the test to `TestRunRemove_NamespacedSkillsIndependent` and add a comment explaining that same-name skills from different deps are treated as independent (no shared directory).
+
+---
+
+### Finding: TestCollectSkillFiles_SameNameDifferentDeps only exercises the happy path
+
+**Severity**: consider  
+**Confidence**: MEDIUM  
+**Category**: testing
+
+#### Grounds (Evidence)
+
+In `internal/cli/install_test.go:249-303`, the new test `TestCollectSkillFiles_SameNameDifferentDeps` verifies the core use case: two dependencies (`github.com/lossyrob/paw` and `github.com/anthropics/skills`) both export a skill named `"skill-creator"`, and both are collected under separate composite keys.
+
+The test verifies:
+1. Both skills exist in the result (line 284-286)
+2. The composite keys are correct (lines 288-290, 296-298)
+3. The file contents are distinct (lines 292-294, 300-302)
+
+This is a good happy-path test, but it doesn't cover realistic variations:
+- What if the two deps export the same skill name **and** have identical file contents? (This is the realistic collision case — two repos independently create a `skill-creator` skill with the same structure)
+- What if one of the deps' skills has an empty SkillPaths entry? (Root-level skill vs subdirectory skill with the same name)
+- What if the two deps are from the same owner but different repos? (`github.com/org/repo-a/skill` vs `github.com/org/repo-b/skill`)
+
+#### Warrant (Rule)
+
+The test verifies that the namespacing mechanism works in principle, but it doesn't stress-test the boundary conditions. The most realistic collision scenario is when two skills have the same name **and** similar or identical content (e.g., both are template generators with similar structure). The test uses different content (`"paw version"` vs `"anthropic version"`), which makes it easy to distinguish them, but that's not the hard case.
+
+The hard case is: same name, same content, different sources. The namespacing should distinguish them by path, but if the content is identical, it's harder to verify that the correct version is installed for each dep. The test doesn't exercise this.
+
+This is a "nice to have" rather than "must fix" because the current test does verify the core mechanism. But if a future bug causes the two skills to overwrite each other (e.g., because the composite key logic is bypassed somewhere), the test might not catch it if the content is identical.
+
+#### Rebuttal Conditions
+
+This is NOT a concern if: (1) the existing test is sufficient to catch all realistic regressions (the distinct content is just for human readability, and the composite key assertions would fail regardless of content); or (2) there are other tests that exercise identical-content scenarios (check: do any tests use the same skill files across multiple deps?).
+
+#### Suggested Verification
+
+Add a test variant: `TestCollectSkillFiles_SameNameIdenticalContent`. Set up:
+- Two deps both export `"formatter"` with identical `SKILL.md` content: `[]byte("---\nname: formatter\n---\n")`
+- Both use the same skill path: `"skills/formatter"`
+
+Assert:
+- Both composite keys exist: `"github.com/org/a/formatter"` and `"github.com/org/b/formatter"`
+- Both have the same content (verifying that identical content doesn't cause a merge or deduplication)
+- The skill map has exactly 2 entries (not 1, which would indicate incorrect deduplication)
+
+This test verifies that the namespacing is based on **source identity**, not content hash.
+
+---
+
+### Finding: Path traversal security tests only cover installer_test.go, not the new namespaced paths in remove.go
+
+**Severity**: consider  
+**Confidence**: MEDIUM  
+**Category**: testing
+
+#### Grounds (Evidence)
+
+In `internal/install/installer_test.go:62-122`, there are comprehensive path traversal security tests:
+- `TestInstallRejectsTraversalSkillName` (line 62): Rejects `"../../etc/malicious"` as a skill name
+- `TestInstallRejectsTraversalFilePath` (line 78): Rejects `"../../etc/passwd"` as a file path
+- `TestInstallRejectsDotSkillName` (line 110): Rejects `"."` as a skill name
+- `TestInstallRejectsEmptySkillName` (line 123): Rejects `""` as a skill name
+
+These tests verify that the `Install()` function has path traversal protections. However, the new `remove.go` logic (lines 238-243, diff) constructs paths with the namespace prefix:
+
+```go
+if nsPrefix != "" {
+    skillDir = filepath.Join(tp, nsPrefix, skillName)
+} else {
+    skillDir = filepath.Join(tp, skillName)
+}
+```
+
+The comment at line 212 (diff line 216) says "Path traversal protection", but there's no **test** verifying that this protection works with the namespaced paths. For example:
+- What if `nsPrefix` contains `../../` (from a malformed URL)?
+- What if `skillName` contains `../../` and is joined with `nsPrefix`?
+- What if the combined `nsPrefix + skillName` escapes the target directory?
+
+The existing installer tests don't cover the removal path, and the remove tests don't have any path traversal cases.
+
+#### Warrant (Rule)
+
+Path traversal vulnerabilities are a high-severity security risk. The removal logic constructs paths dynamically from `nsPrefix` (derived from `ParseDepURL`) and `skillName` (from the pinfile). If either of these inputs can be controlled by an attacker (e.g., via a crafted pinfile or malicious dependency), and the path traversal checks fail, an attacker could delete arbitrary directories on the user's system.
+
+The existing path traversal protections in `installer.go` (lines 246-261 of the file, not in the diff) use `filepath.Abs` and `strings.HasPrefix` to verify that the final path is within the target directory. The removal logic at line 246-261 of `remove.go` (diff lines 246-261) has **identical checks**:
+
+```go
+absSkillDir, err := filepath.Abs(skillDir)
+if err != nil {
+    continue
+}
+absTP, err := filepath.Abs(tp)
+if err != nil {
+    continue
+}
+if !strings.HasPrefix(absSkillDir, absTP+string(filepath.Separator)) {
+    fmt.Fprintf(cmd.ErrOrStderr(), "Skipping %s (path escapes target)\n", skillName)
+    continue
+}
+```
+
+This is good defense-in-depth, but there's no **test** verifying it works. If a future refactor removes or weakens these checks (e.g., changes `HasPrefix` to `Contains`), there's no test that would fail.
+
+#### Rebuttal Conditions
+
+This is NOT a concern if: (1) `nsPrefix` is guaranteed to never contain `..` or other traversal sequences because `ParseDepURL` validates and normalizes it (check the `ParseDepURL` implementation and tests); AND (2) `skillName` is guaranteed to never contain traversal sequences because the manifest/pinfile validation rejects them (check the validation logic). If both inputs are validated upstream, the remove.go checks are defense-in-depth and don't need dedicated tests.
+
+#### Suggested Verification
+
+Add test: `TestRunRemove_RejectsTraversalInNamespacedPath`. Set up:
+- Create a pinfile with a crafted entry: `"github.com/../../etc/passwd@v1.0.0"` (malicious nsPrefix)
+- Or create a pinfile with a skill name containing traversal: `"../../../etc/shadow"`
+
+Attempt to run `remove` for that dependency. Assert:
+- The command does not crash or panic
+- No files outside the target directory are deleted
+- A warning message is printed: `"Skipping ... (path escapes target)"`
+
+This test verifies that the defense-in-depth checks in `remove.go` actually work. If they do, the test passes. If they're bypassed or broken, the test fails (or worse, deletes the wrong files).
+
+---
+
+### Finding: No test verifies that cleanEmptyParents stops before deleting the target root
+
+**Severity**: must-fix  
+**Confidence**: HIGH  
+**Category**: testing
+
+#### Grounds (Evidence)
+
+This is a specific boundary case for `cleanEmptyParents()` that deserves its own finding because it's the **most dangerous** failure mode. In `remove.go:265-282`, the loop condition is:
+
+```go
+if err != nil || absDir == absRoot || !strings.HasPrefix(absDir, absRoot+string(filepath.Separator)) {
+    break
+}
+```
+
+The check `absDir == absRoot` is supposed to stop the loop before deleting the root itself. However, this check is **implicit** — it's not obvious from the code whether it actually works. The test at `TestRunRemove_ExistingDep` (line 87-89) verifies that `github.com/org/repo` is cleaned up, but it doesn't explicitly verify that the target directory (`installed/`) itself is **not** deleted.
+
+Consider the scenario:
+- Target root: `/home/user/.copilot/skills`
+- Skill path: `/home/user/.copilot/skills/github.com/org/repo/skill`
+- After removing the skill, `cleanEmptyParents` walks up: `repo/` → `org/` → `github.com/` → `skills/`
+
+The question: does it stop at `skills/` (correct), or does it try to delete `skills/` (incorrect)? The code says it should stop because of the `absDir == absRoot` check, but there's no test proving this works.
+
+If the check is wrong (e.g., off-by-one), the function could delete the user's entire skill directory, causing data loss for all other skills.
+
+#### Warrant (Rule)
+
+Boundary condition: the loop termination condition for recursive algorithms is the most common source of off-by-one errors. The classic mistake is `<` vs `<=`, or `==` vs `!=`. In this case, the check is `absDir == absRoot`, which means "stop when we reach root." But what if:
+
+1. The check is **before** the delete, so it stops at root (correct) ✓
+2. The check is **after** the delete, so it deletes root and then stops (incorrect) ✗
+
+Looking at the code (lines 276-279):
+```go
+if err := os.Remove(dir); err != nil {
+    break // not empty or permission error
+}
+dir = filepath.Dir(dir)
+```
+
+The delete happens first, **then** `dir` is updated to the parent. On the next iteration, the check `absDir == absRoot` is evaluated. So the sequence is:
+1. Delete `github.com/` (suppose this was the last dir to delete)
+2. Update `dir` to `skills/` (the parent, which is root)
+3. Next iteration: check `absDir == absRoot` → true → break
+
+So it **should not** delete root. But this is subtle and not obvious from a code review. A test would make this explicit.
+
+#### Rebuttal Conditions
+
+This is NOT a concern if: (1) the integration test at `TestRunRemove_ExistingDep` explicitly asserts that the target directory still exists after cleanup (check line 82-89: does it verify that `targetDir` exists?); or (2) there's a separate unit test for `cleanEmptyParents` that covers this case (there isn't, per Finding 1).
+
+#### Suggested Verification
+
+Add test: `TestCleanEmptyParents_StopsAtRoot`. Set up:
+```go
+root := t.TempDir()
+nestedDir := filepath.Join(root, "a", "b", "c")
+os.MkdirAll(nestedDir, 0755)
+
+cleanEmptyParents(root, nestedDir)
+
+// Verify nested dirs are gone
+if _, err := os.Stat(nestedDir); err == nil {
+    t.Error("nested dir should be removed")
+}
+// Verify root still exists
+if _, err := os.Stat(root); err != nil {
+    t.Error("root should NOT be removed")
+}
+```
+
+This test explicitly verifies the boundary condition: `cleanEmptyParents` removes all empty parents up to (but not including) root.
+
+---
+
+## Summary of High-Priority Actions
+
+1. **Add unit tests for `cleanEmptyParents()`** covering all boundary conditions (root boundary, non-empty parents, error handling)
+2. **Add test for `verifyIntegrity()` ParseDepURL error path** to verify behavior when URL parsing fails
+3. **Add tests for non-GitHub hosts** (GitLab, Bitbucket, self-hosted) per spec requirement SC-005
+4. **Update or clarify `TestRunRemove_SharedSkillRetained`** to verify namespaced behavior correctly
+5. **Add explicit test for cleanEmptyParents root boundary** to prevent deletion of target root
+
+## Test Quality Assessment
+
+**Strengths**:
+- Existing tests were correctly updated for namespaced paths (all composite keys use `"github.com/org/repo/skill"` format)
+- Good coverage of atomic install and path traversal security in `installer_test.go`
+- New test `TestCollectSkillFiles_SameNameDifferentDeps` directly exercises the core use case
+
+**Weaknesses**:
+- **No unit tests** for new `cleanEmptyParents()` function (recursive deletion is high-risk)
+- **Error paths are under-tested**: ParseDepURL failure in `verifyIntegrity()`, non-GitHub hosts
+- **Boundary conditions are implicit**: Root boundary for cleanup, empty parent handling
+- **One test was simplified** (`TestRunRemove_SharedSkillRetained`) and may no longer verify the intended behavior
+
+**Risk Assessment**:
+The highest risk is in the `cleanEmptyParents()` function — it's new, untested, and performs recursive directory deletion. A bug here could cause data loss (deleting too much) or directory pollution (not cleaning up empty dirs). The second-highest risk is the silent `continue` in `verifyIntegrity()` when ParseDepURL fails — this could skip integrity checks for malformed deps, opening a security hole.
+

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -255,6 +255,7 @@ func collectSkillFiles(fetcher fetch.GitFetcher, result *resolve.ResolveResult) 
 		}
 
 		cloneURL := fetch.NormalizeCloneURL(parsed.PackageIdentity())
+		prefix := parsed.PackageIdentity()
 
 		// Fetch tree once per dependency
 		allPaths, err := fetcher.ListTree(cloneURL, dep.Commit)
@@ -275,15 +276,17 @@ func collectSkillFiles(fetcher fetch.GitFetcher, result *resolve.ResolveResult) 
 
 			// Remap paths to be relative to skill directory
 			if skillDir != "" {
-				prefix := skillDir + "/"
+				dirPrefix := skillDir + "/"
 				mapped := make(map[string][]byte, len(files))
 				for p, content := range files {
-					mapped[strings.TrimPrefix(p, prefix)] = content
+					mapped[strings.TrimPrefix(p, dirPrefix)] = content
 				}
 				files = mapped
 			}
 
-			skills[skillName] = files
+			// Namespace by host/owner/repo to avoid cross-dep collisions
+			compositeKey := prefix + "/" + skillName
+			skills[compositeKey] = files
 		}
 	}
 
@@ -300,20 +303,27 @@ func verifyIntegrity(result *resolve.ResolveResult, skills map[string]map[string
 			continue
 		}
 
+		parsed, err := resolve.ParseDepURL(dep.URL)
+		if err != nil {
+			continue
+		}
+		prefix := parsed.PackageIdentity()
+
 		// Reconstruct combined file map with original paths (matching resolver)
 		combined := make(map[string][]byte)
 		for i, skillName := range dep.Skills {
-			var prefix string
+			var skillPathPrefix string
 			if i < len(dep.SkillPaths) && dep.SkillPaths[i] != "" {
-				prefix = dep.SkillPaths[i] + "/"
+				skillPathPrefix = dep.SkillPaths[i] + "/"
 			}
 
-			skillFiles, ok := skills[skillName]
+			compositeKey := prefix + "/" + skillName
+			skillFiles, ok := skills[compositeKey]
 			if !ok {
 				continue
 			}
 			for relPath, content := range skillFiles {
-				combined[prefix+relPath] = content
+				combined[skillPathPrefix+relPath] = content
 			}
 		}
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -305,7 +305,7 @@ func verifyIntegrity(result *resolve.ResolveResult, skills map[string]map[string
 
 		parsed, err := resolve.ParseDepURL(dep.URL)
 		if err != nil {
-			continue
+			return fmt.Errorf("verifying integrity for %s: %w", dep.URL, err)
 		}
 		prefix := parsed.PackageIdentity()
 

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -355,9 +355,15 @@ func TestCollectSkillFiles_SkillPathsShorterThanSkills(t *testing.T) {
 		t.Fatalf("collectSkillFiles returned error: %v", err)
 	}
 
-	// Both skills should be present
+	// Both skills should be present with composite keys
 	if len(skills) != 2 {
 		t.Errorf("expected 2 skills, got %d", len(skills))
+	}
+	if _, ok := skills["github.com/org/repo/skill1"]; !ok {
+		t.Error("expected composite key 'github.com/org/repo/skill1'")
+	}
+	if _, ok := skills["github.com/org/repo/skill2"]; !ok {
+		t.Error("expected composite key 'github.com/org/repo/skill2'")
 	}
 }
 
@@ -577,5 +583,35 @@ func TestVerifyIntegrity_SkipsMissingPinEntry(t *testing.T) {
 
 	if err := verifyIntegrity(result, skillFiles); err != nil {
 		t.Fatalf("verifyIntegrity should skip deps without pinfile entry, got: %v", err)
+	}
+}
+
+func TestVerifyIntegrity_BadDepURL(t *testing.T) {
+	skillFiles := map[string]map[string][]byte{
+		"github.com/org/repo/lint": {"SKILL.md": []byte("content")},
+	}
+
+	result := &resolve.ResolveResult{
+		Resolved: []resolve.ResolvedDep{
+			{
+				URL:    "not-a-valid-url",
+				Commit: "abc123",
+				Skills: []string{"lint"},
+			},
+		},
+		Pinfile: &pinfile.Pinfile{
+			PinVersion: 1,
+			Resolved: map[string]pinfile.ResolvedEntry{
+				"not-a-valid-url": {Integrity: "sha256:abc"},
+			},
+		},
+	}
+
+	err := verifyIntegrity(result, skillFiles)
+	if err == nil {
+		t.Fatal("expected error for invalid dep URL")
+	}
+	if !strings.Contains(err.Error(), "verifying integrity for") {
+		t.Errorf("error should mention context, got: %v", err)
 	}
 }

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -44,9 +44,9 @@ func TestCollectSkillFiles_SingleDep(t *testing.T) {
 		t.Fatalf("expected 1 skill, got %d", len(skills))
 	}
 
-	lintFiles, ok := skills["lint"]
+	lintFiles, ok := skills["github.com/org/repo/lint"]
 	if !ok {
-		t.Fatal("expected skill 'lint' in result")
+		t.Fatal("expected skill 'github.com/org/repo/lint' in result")
 	}
 
 	if len(lintFiles) != 2 {
@@ -106,7 +106,7 @@ func TestCollectSkillFiles_MultipleDeps(t *testing.T) {
 		t.Fatalf("expected 3 skills, got %d", len(skills))
 	}
 
-	for _, name := range []string{"lint", "format", "debug"} {
+	for _, name := range []string{"github.com/org/skills/lint", "github.com/org/skills/format", "github.com/org/tools/debug"} {
 		if _, ok := skills[name]; !ok {
 			t.Errorf("expected skill %q in result", name)
 		}
@@ -141,7 +141,7 @@ func TestCollectSkillFiles_EmptySkillPath(t *testing.T) {
 		t.Fatalf("collectSkillFiles returned error: %v", err)
 	}
 
-	files := skills["single-skill"]
+	files := skills["github.com/org/single-skill/single-skill"]
 	if len(files) != 2 {
 		t.Fatalf("expected 2 files, got %d", len(files))
 	}
@@ -196,7 +196,7 @@ func TestCollectSkillFiles_SkipsListTreeFailure(t *testing.T) {
 	}
 
 	// Skill entry may exist but with no files
-	if files, ok := skills["missing-tree"]; ok && len(files) > 0 {
+	if files, ok := skills["github.com/org/repo/missing-tree"]; ok && len(files) > 0 {
 		t.Errorf("expected empty files for missing tree, got %d files", len(files))
 	}
 }
@@ -226,7 +226,7 @@ func TestCollectSkillFiles_SkipsReadFilesFailure(t *testing.T) {
 	}
 
 	// Skill exists but files map should be empty (file key not in mock)
-	if files, ok := skills["broken"]; ok && len(files) > 0 {
+	if files, ok := skills["github.com/org/repo/broken"]; ok && len(files) > 0 {
 		t.Errorf("expected empty files for unreadable skill, got %d", len(files))
 	}
 }
@@ -243,6 +243,62 @@ func TestCollectSkillFiles_NoResolvedDeps(t *testing.T) {
 	}
 	if len(skills) != 0 {
 		t.Errorf("expected 0 skills, got %d", len(skills))
+	}
+}
+
+func TestCollectSkillFiles_SameNameDifferentDeps(t *testing.T) {
+	mock := fetch.NewMockFetcher()
+
+	// Two deps both export "skill-creator"
+	url1 := "https://github.com/lossyrob/paw.git"
+	mock.Trees[url1+":commit1"] = []string{"skills/skill-creator/SKILL.md"}
+	mock.Files[url1+":commit1:skills/skill-creator/SKILL.md"] = []byte("paw version")
+
+	url2 := "https://github.com/anthropics/skills.git"
+	mock.Trees[url2+":commit2"] = []string{"skills/skill-creator/SKILL.md"}
+	mock.Files[url2+":commit2:skills/skill-creator/SKILL.md"] = []byte("anthropic version")
+
+	result := &resolve.ResolveResult{
+		Resolved: []resolve.ResolvedDep{
+			{
+				URL:        "github.com/lossyrob/paw@v1.0.0",
+				Commit:     "commit1",
+				Skills:     []string{"skill-creator"},
+				SkillPaths: []string{"skills/skill-creator"},
+			},
+			{
+				URL:        "github.com/anthropics/skills@v1.0.0",
+				Commit:     "commit2",
+				Skills:     []string{"skill-creator"},
+				SkillPaths: []string{"skills/skill-creator"},
+			},
+		},
+	}
+
+	skills, err := collectSkillFiles(mock, result)
+	if err != nil {
+		t.Fatalf("collectSkillFiles returned error: %v", err)
+	}
+
+	// Both should exist under namespaced keys
+	if len(skills) != 2 {
+		t.Fatalf("expected 2 skills, got %d", len(skills))
+	}
+
+	pawFiles, ok := skills["github.com/lossyrob/paw/skill-creator"]
+	if !ok {
+		t.Fatal("expected 'github.com/lossyrob/paw/skill-creator' in result")
+	}
+	if string(pawFiles["SKILL.md"]) != "paw version" {
+		t.Errorf("unexpected PAW content: %q", pawFiles["SKILL.md"])
+	}
+
+	antFiles, ok := skills["github.com/anthropics/skills/skill-creator"]
+	if !ok {
+		t.Fatal("expected 'github.com/anthropics/skills/skill-creator' in result")
+	}
+	if string(antFiles["SKILL.md"]) != "anthropic version" {
+		t.Errorf("unexpected Anthropic content: %q", antFiles["SKILL.md"])
 	}
 }
 
@@ -389,9 +445,9 @@ func TestResolveInstallTargets_ExplicitPath(t *testing.T) {
 }
 
 func TestVerifyIntegrity_Pass(t *testing.T) {
-	// Build skill files matching what the resolver would produce
+	// Build skill files matching what collectSkillFiles would produce (composite keys)
 	skillFiles := map[string]map[string][]byte{
-		"lint": {
+		"github.com/org/repo/lint": {
 			"SKILL.md":   []byte("---\nname: lint\n---\n"),
 			"rules.yaml": []byte("rules: []"),
 		},
@@ -433,7 +489,7 @@ func TestVerifyIntegrity_Pass(t *testing.T) {
 func TestVerifyIntegrity_Mismatch(t *testing.T) {
 	// Skill files that don't match the pinfile digest (simulating cache poisoning)
 	skillFiles := map[string]map[string][]byte{
-		"lint": {
+		"github.com/org/repo/lint": {
 			"SKILL.md": []byte("TAMPERED CONTENT"),
 		},
 	}
@@ -473,7 +529,7 @@ func TestVerifyIntegrity_Mismatch(t *testing.T) {
 
 func TestVerifyIntegrity_SkipsMissingPinEntry(t *testing.T) {
 	skillFiles := map[string]map[string][]byte{
-		"lint": {"SKILL.md": []byte("content")},
+		"github.com/org/repo/lint": {"SKILL.md": []byte("content")},
 	}
 
 	result := &resolve.ResolveResult{

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -302,6 +302,34 @@ func TestCollectSkillFiles_SameNameDifferentDeps(t *testing.T) {
 	}
 }
 
+func TestCollectSkillFiles_NonGitHubHost(t *testing.T) {
+	mock := fetch.NewMockFetcher()
+
+	url := "https://gitlab.example.io/my-org/internal-skills.git"
+	mock.Trees[url+":commit1"] = []string{"skills/deploy/SKILL.md"}
+	mock.Files[url+":commit1:skills/deploy/SKILL.md"] = []byte("deploy skill")
+
+	result := &resolve.ResolveResult{
+		Resolved: []resolve.ResolvedDep{
+			{
+				URL:        "gitlab.example.io/my-org/internal-skills@v1.0.0",
+				Commit:     "commit1",
+				Skills:     []string{"deploy"},
+				SkillPaths: []string{"skills/deploy"},
+			},
+		},
+	}
+
+	skills, err := collectSkillFiles(mock, result)
+	if err != nil {
+		t.Fatalf("collectSkillFiles returned error: %v", err)
+	}
+
+	if _, ok := skills["gitlab.example.io/my-org/internal-skills/deploy"]; !ok {
+		t.Fatal("expected non-GitHub host namespace key 'gitlab.example.io/my-org/internal-skills/deploy'")
+	}
+}
+
 func TestCollectSkillFiles_SkillPathsShorterThanSkills(t *testing.T) {
 	mock := fetch.NewMockFetcher()
 	cloneURL := "https://github.com/org/repo.git"

--- a/internal/cli/remove.go
+++ b/internal/cli/remove.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/erdemtuna/craft/internal/manifest"
 	"github.com/erdemtuna/craft/internal/pinfile"
+	"github.com/erdemtuna/craft/internal/resolve"
 	"github.com/spf13/cobra"
 )
 
@@ -111,11 +112,23 @@ func runRemove(cmd *cobra.Command, args []string) error {
 				return nil
 			}
 
+			// Parse dep URL to get namespace prefix (host/owner/repo)
+			parsed, parseErr := resolve.ParseDepURL(depURL)
+			var nsPrefix string
+			if parseErr == nil {
+				nsPrefix = parsed.PackageIdentity()
+			}
+
 			var cleaned []string
 			for _, skillName := range orphaned {
 				removed := false
 				for _, tp := range targetPath {
-					skillDir := filepath.Join(tp, skillName)
+					var skillDir string
+					if nsPrefix != "" {
+						skillDir = filepath.Join(tp, nsPrefix, skillName)
+					} else {
+						skillDir = filepath.Join(tp, skillName)
+					}
 					// Path traversal protection
 					absSkillDir, err := filepath.Abs(skillDir)
 					if err != nil {
@@ -137,6 +150,11 @@ func runRemove(cmd *cobra.Command, args []string) error {
 							removed = true
 						}
 					}
+
+					// Clean up empty parent directories up to target root
+					if removed && nsPrefix != "" {
+						cleanEmptyParents(tp, filepath.Dir(skillDir))
+					}
 				}
 				if removed {
 					cleaned = append(cleaned, skillName)
@@ -150,6 +168,25 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// cleanEmptyParents removes empty directories from dir up to (but not
+// including) root. Uses os.Remove which fails on non-empty dirs — safe.
+func cleanEmptyParents(root, dir string) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return
+	}
+	for {
+		absDir, err := filepath.Abs(dir)
+		if err != nil || absDir == absRoot || !strings.HasPrefix(absDir, absRoot+string(filepath.Separator)) {
+			break
+		}
+		if err := os.Remove(dir); err != nil {
+			break // not empty or permission error
+		}
+		dir = filepath.Dir(dir)
+	}
 }
 
 // availableAliases formats the available dependency aliases for error messages.

--- a/internal/cli/remove.go
+++ b/internal/cli/remove.go
@@ -77,16 +77,6 @@ func runRemove(cmd *cobra.Command, args []string) error {
 
 	// Update pinfile
 	if pfErr == nil {
-		// Collect all skills still needed by remaining dependencies
-		remainingSkills := make(map[string]bool)
-		for _, remainingURL := range m.Dependencies {
-			if entry, ok := pf.Resolved[remainingURL]; ok {
-				for _, s := range entry.Skills {
-					remainingSkills[s] = true
-				}
-			}
-		}
-
 		// Remove the dep entry from pinfile
 		delete(pf.Resolved, depURL)
 
@@ -95,13 +85,9 @@ func runRemove(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		// Find orphaned skills (only in removed dep, not in any remaining dep)
-		var orphaned []string
-		for _, s := range removedSkills {
-			if !remainingSkills[s] {
-				orphaned = append(orphaned, s)
-			}
-		}
+		// With namespaced paths, every skill from the removed dep has a
+		// unique disk path (host/owner/repo/skill), so all are orphaned.
+		orphaned := removedSkills
 
 		// Clean up orphaned skills from install target
 		if len(orphaned) > 0 {
@@ -114,21 +100,18 @@ func runRemove(cmd *cobra.Command, args []string) error {
 
 			// Parse dep URL to get namespace prefix (host/owner/repo)
 			parsed, parseErr := resolve.ParseDepURL(depURL)
-			var nsPrefix string
-			if parseErr == nil {
-				nsPrefix = parsed.PackageIdentity()
+			if parseErr != nil {
+				cmd.PrintErrf("  warning: could not parse dep URL %q for cleanup: %v\n", depURL, parseErr)
+				cmd.Printf("  orphaned skills (manual cleanup needed): %s\n", strings.Join(orphaned, ", "))
+				return nil
 			}
+			nsPrefix := parsed.PackageIdentity()
 
 			var cleaned []string
 			for _, skillName := range orphaned {
-				removed := false
+				removedFromAny := false
 				for _, tp := range targetPath {
-					var skillDir string
-					if nsPrefix != "" {
-						skillDir = filepath.Join(tp, nsPrefix, skillName)
-					} else {
-						skillDir = filepath.Join(tp, skillName)
-					}
+					skillDir := filepath.Join(tp, nsPrefix, skillName)
 					// Path traversal protection
 					absSkillDir, err := filepath.Abs(skillDir)
 					if err != nil {
@@ -147,16 +130,12 @@ func runRemove(cmd *cobra.Command, args []string) error {
 						if err := os.RemoveAll(skillDir); err != nil {
 							cmd.PrintErrf("  warning: could not remove %s: %v\n", skillDir, err)
 						} else {
-							removed = true
+							removedFromAny = true
+							cleanEmptyParents(tp, filepath.Dir(skillDir))
 						}
 					}
-
-					// Clean up empty parent directories up to target root
-					if removed && nsPrefix != "" {
-						cleanEmptyParents(tp, filepath.Dir(skillDir))
-					}
 				}
-				if removed {
+				if removedFromAny {
 					cleaned = append(cleaned, skillName)
 				}
 			}

--- a/internal/cli/remove_test.go
+++ b/internal/cli/remove_test.go
@@ -40,10 +40,10 @@ resolved:
 `
 	_ = os.WriteFile(filepath.Join(dir, "craft.pin.yaml"), []byte(pinContent), 0644)
 
-	// Create installed skill directory
+	// Create installed skill directory (namespaced: target/host/owner/repo/skill)
 	targetDir := filepath.Join(dir, "installed")
-	_ = os.MkdirAll(filepath.Join(targetDir, "repo-skill"), 0755)
-	_ = os.WriteFile(filepath.Join(targetDir, "repo-skill", "SKILL.md"), []byte("skill"), 0644)
+	_ = os.MkdirAll(filepath.Join(targetDir, "github.com", "org", "repo", "repo-skill"), 0755)
+	_ = os.WriteFile(filepath.Join(targetDir, "github.com", "org", "repo", "repo-skill", "SKILL.md"), []byte("skill"), 0644)
 
 	oldWd, _ := os.Getwd()
 	defer func() { _ = os.Chdir(oldWd) }()
@@ -79,9 +79,13 @@ resolved:
 		t.Error("pinfile should not contain removed dep")
 	}
 
-	// Verify orphaned skill cleaned up
-	if _, err := os.Stat(filepath.Join(targetDir, "repo-skill")); err == nil {
+	// Verify orphaned skill cleaned up (namespaced path)
+	if _, err := os.Stat(filepath.Join(targetDir, "github.com", "org", "repo", "repo-skill")); err == nil {
 		t.Error("orphaned skill directory should have been removed")
+	}
+	// Verify empty parent dirs cleaned up
+	if _, err := os.Stat(filepath.Join(targetDir, "github.com", "org", "repo")); err == nil {
+		t.Error("empty repo directory should have been cleaned up")
 	}
 }
 
@@ -154,10 +158,10 @@ resolved:
 `
 	_ = os.WriteFile(filepath.Join(dir, "craft.pin.yaml"), []byte(pinContent), 0644)
 
-	// Create installed skill directories
+	// Create installed skill directories (namespaced)
 	targetDir := filepath.Join(dir, "installed")
-	_ = os.MkdirAll(filepath.Join(targetDir, "shared-skill"), 0755)
-	_ = os.MkdirAll(filepath.Join(targetDir, "unique-a"), 0755)
+	_ = os.MkdirAll(filepath.Join(targetDir, "github.com", "org", "a", "shared-skill"), 0755)
+	_ = os.MkdirAll(filepath.Join(targetDir, "github.com", "org", "a", "unique-a"), 0755)
 
 	oldWd, _ := os.Getwd()
 	defer func() { _ = os.Chdir(oldWd) }()
@@ -174,12 +178,11 @@ resolved:
 	}
 
 	// shared-skill should be retained (dep-b still provides it)
-	if _, err := os.Stat(filepath.Join(targetDir, "shared-skill")); err != nil {
-		t.Error("shared skill should have been retained")
-	}
-
-	// unique-a should be cleaned up
-	if _, err := os.Stat(filepath.Join(targetDir, "unique-a")); err == nil {
+	// Note: with namespacing, shared-skill from dep-a lives under github.com/org/a/
+	// and dep-b's shared-skill would live under github.com/org/b/ — they're separate paths.
+	// The orphan check still uses skill NAMES, but the disk paths are namespaced.
+	// unique-a should be cleaned up since only dep-a provided it
+	if _, err := os.Stat(filepath.Join(targetDir, "github.com", "org", "a", "unique-a")); err == nil {
 		t.Error("unique-a should have been removed")
 	}
 }
@@ -210,7 +213,7 @@ resolved:
 	_ = os.WriteFile(filepath.Join(dir, "craft.pin.yaml"), []byte(pinContent), 0644)
 
 	targetDir := filepath.Join(dir, "installed")
-	_ = os.MkdirAll(filepath.Join(targetDir, "the-skill"), 0755)
+	_ = os.MkdirAll(filepath.Join(targetDir, "github.com", "org", "repo", "the-skill"), 0755)
 
 	oldWd, _ := os.Getwd()
 	defer func() { _ = os.Chdir(oldWd) }()

--- a/internal/cli/remove_test.go
+++ b/internal/cli/remove_test.go
@@ -177,10 +177,13 @@ resolved:
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// shared-skill should be retained (dep-b still provides it)
-	// Note: with namespacing, shared-skill from dep-a lives under github.com/org/a/
-	// and dep-b's shared-skill would live under github.com/org/b/ — they're separate paths.
-	// The orphan check still uses skill NAMES, but the disk paths are namespaced.
+	// With namespacing, shared-skill from dep-a lives under github.com/org/a/
+	// and dep-b's shared-skill lives under github.com/org/b/ — independent paths.
+	// Removing dep-a should clean up ALL of dep-a's skills regardless of name overlap.
+	if _, err := os.Stat(filepath.Join(targetDir, "github.com", "org", "a", "shared-skill")); err == nil {
+		t.Error("dep-a's shared-skill should have been removed (namespaced paths are independent)")
+	}
+
 	// unique-a should be cleaned up since only dep-a provided it
 	if _, err := os.Stat(filepath.Join(targetDir, "github.com", "org", "a", "unique-a")); err == nil {
 		t.Error("unique-a should have been removed")
@@ -251,5 +254,62 @@ func TestAvailableAliases_Empty(t *testing.T) {
 	got := availableAliases(nil)
 	if got != "(none)" {
 		t.Errorf("expected '(none)', got: %s", got)
+	}
+}
+
+func TestCleanEmptyParents(t *testing.T) {
+	root := t.TempDir()
+
+	// Create nested empty dirs: root/a/b/c/
+	nested := filepath.Join(root, "a", "b", "c")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Clean from c upward
+	cleanEmptyParents(root, nested)
+
+	// All empty parents should be removed
+	if _, err := os.Stat(filepath.Join(root, "a")); err == nil {
+		t.Error("expected 'a' to be removed")
+	}
+	// Root itself should remain
+	if _, err := os.Stat(root); err != nil {
+		t.Error("root should still exist")
+	}
+}
+
+func TestCleanEmptyParents_StopsAtNonEmpty(t *testing.T) {
+	root := t.TempDir()
+
+	// Create root/a/b/c/ where a/sibling exists
+	nested := filepath.Join(root, "a", "b", "c")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatal(err)
+	}
+	sibling := filepath.Join(root, "a", "sibling")
+	if err := os.MkdirAll(sibling, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cleanEmptyParents(root, nested)
+
+	// b and c removed, but a remains (has sibling)
+	if _, err := os.Stat(filepath.Join(root, "a", "b")); err == nil {
+		t.Error("expected 'b' to be removed")
+	}
+	if _, err := os.Stat(filepath.Join(root, "a")); err != nil {
+		t.Error("'a' should remain (has sibling)")
+	}
+}
+
+func TestCleanEmptyParents_StopsAtRoot(t *testing.T) {
+	root := t.TempDir()
+
+	// dir IS root — should not delete root
+	cleanEmptyParents(root, root)
+
+	if _, err := os.Stat(root); err != nil {
+		t.Error("root should not be deleted")
 	}
 }

--- a/internal/cli/remove_test.go
+++ b/internal/cli/remove_test.go
@@ -162,6 +162,8 @@ resolved:
 	targetDir := filepath.Join(dir, "installed")
 	_ = os.MkdirAll(filepath.Join(targetDir, "github.com", "org", "a", "shared-skill"), 0755)
 	_ = os.MkdirAll(filepath.Join(targetDir, "github.com", "org", "a", "unique-a"), 0755)
+	_ = os.MkdirAll(filepath.Join(targetDir, "github.com", "org", "b", "shared-skill"), 0755)
+	_ = os.WriteFile(filepath.Join(targetDir, "github.com", "org", "b", "shared-skill", "SKILL.md"), []byte("dep-b skill"), 0644)
 
 	oldWd, _ := os.Getwd()
 	defer func() { _ = os.Chdir(oldWd) }()
@@ -187,6 +189,11 @@ resolved:
 	// unique-a should be cleaned up since only dep-a provided it
 	if _, err := os.Stat(filepath.Join(targetDir, "github.com", "org", "a", "unique-a")); err == nil {
 		t.Error("unique-a should have been removed")
+	}
+
+	// dep-b's identically-named skill should survive dep-a removal
+	if _, err := os.Stat(filepath.Join(targetDir, "github.com", "org", "b", "shared-skill")); err != nil {
+		t.Error("dep-b's shared-skill should survive dep-a removal (independent namespaced paths)")
 	}
 }
 
@@ -254,6 +261,53 @@ func TestAvailableAliases_Empty(t *testing.T) {
 	got := availableAliases(nil)
 	if got != "(none)" {
 		t.Errorf("expected '(none)', got: %s", got)
+	}
+}
+
+func TestRunRemove_BadDepURLWarns(t *testing.T) {
+	dir := t.TempDir()
+
+	manifestContent := `schema_version: 1
+name: test-pkg
+version: 0.1.0
+skills:
+  - ./skills/s
+dependencies:
+  bad-dep: "not-a-valid-url"
+`
+	_ = os.WriteFile(filepath.Join(dir, "craft.yaml"), []byte(manifestContent), 0644)
+	_ = os.MkdirAll(filepath.Join(dir, "skills", "s"), 0755)
+	_ = os.WriteFile(filepath.Join(dir, "skills", "s", "SKILL.md"), []byte("---\nname: s\n---\n"), 0644)
+
+	pinContent := `pin_version: 1
+resolved:
+  not-a-valid-url:
+    commit: abc123
+    integrity: sha256-test
+    skills:
+      - some-skill
+`
+	_ = os.WriteFile(filepath.Join(dir, "craft.pin.yaml"), []byte(pinContent), 0644)
+
+	targetDir := filepath.Join(dir, "installed")
+	_ = os.MkdirAll(targetDir, 0755)
+
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	_ = os.Chdir(dir)
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"remove", "--target", targetDir, "bad-dep"})
+	err := rootCmd.Execute()
+
+	if err != nil {
+		t.Fatalf("remove should succeed even with bad dep URL, got: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "warning: could not parse dep URL") {
+		t.Errorf("expected warning about unparseable dep URL, got: %s", output)
 	}
 }
 

--- a/internal/install/installer.go
+++ b/internal/install/installer.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 )
 
-// Install copies skill files to the target directory as <target>/<skill-name>/.
-// Each entry in skills maps skill name to a map of relative file paths to contents.
+// Install copies skill files to the target directory.
+// Each entry in skills maps a composite key (host/owner/repo/skill-name) to
+// a map of relative file paths to contents. The composite key naturally creates
+// nested directories via filepath.Join.
 // Files are written to a staging directory first and swapped into place to avoid
 // leaving a skill in a partially-installed state if the process is interrupted.
 func Install(target string, skills map[string]map[string][]byte) error {

--- a/internal/install/installer_test.go
+++ b/internal/install/installer_test.go
@@ -175,3 +175,36 @@ func TestInstallAtomicOverwrite(t *testing.T) {
 		t.Fatalf("skill dir should exist: %v", err)
 	}
 }
+
+func TestInstallCompositeKeys(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "skills")
+	skills := map[string]map[string][]byte{
+		"github.com/org/repo/my-skill": {
+			"SKILL.md": []byte("---\nname: my-skill\n---\n"),
+		},
+		"github.com/other/tools/my-skill": {
+			"SKILL.md": []byte("---\nname: my-skill\n---\nfrom other"),
+		},
+	}
+
+	if err := Install(target, skills); err != nil {
+		t.Fatalf("Install error: %v", err)
+	}
+
+	// Both skills should exist at different paths
+	content1, err := os.ReadFile(filepath.Join(target, "github.com", "org", "repo", "my-skill", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("ReadFile error for org/repo: %v", err)
+	}
+	if !strings.Contains(string(content1), "name: my-skill") {
+		t.Errorf("Unexpected content for org/repo: %q", content1)
+	}
+
+	content2, err := os.ReadFile(filepath.Join(target, "github.com", "other", "tools", "my-skill", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("ReadFile error for other/tools: %v", err)
+	}
+	if !strings.Contains(string(content2), "from other") {
+		t.Errorf("Unexpected content for other/tools: %q", content2)
+	}
+}

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -237,12 +237,7 @@ func (r *Resolver) Resolve(m *manifest.Manifest, opts ResolveOptions) (*ResolveR
 		return resolved[i].URL < resolved[j].URL
 	})
 
-	// Phase 5: Skill name collision detection
-	if err := detectCollisions(resolved); err != nil {
-		return nil, err
-	}
-
-	// Phase 6: Build pinfile
+	// Phase 5: Build pinfile
 	pf := &pinfile.Pinfile{
 		PinVersion: 1,
 		Resolved:   make(map[string]pinfile.ResolvedEntry),
@@ -503,34 +498,6 @@ func (r *Resolver) autoDiscoverSkills(cloneURL, commitSHA string) ([]string, []s
 	}
 
 	return names, dirs, allFiles, nil
-}
-
-// detectCollisions checks for duplicate skill names across resolved deps.
-func detectCollisions(resolved []ResolvedDep) error {
-	type skillSource struct {
-		depURL string
-		commit string
-	}
-
-	seen := make(map[string]skillSource)
-	for _, dep := range resolved {
-		for _, name := range dep.Skills {
-			if existing, ok := seen[name]; ok {
-				existShort := existing.commit
-				if len(existShort) > 8 {
-					existShort = existShort[:8]
-				}
-				depShort := dep.Commit
-				if len(depShort) > 8 {
-					depShort = depShort[:8]
-				}
-				return fmt.Errorf("skill name collision: %q is exported by both %s (commit %s) and %s (commit %s)",
-					name, existing.depURL, existShort, dep.URL, depShort)
-			}
-			seen[name] = skillSource{depURL: dep.URL, commit: dep.Commit}
-		}
-	}
-	return nil
 }
 
 // CollectSkillDirFiles filters allPaths by skillDir, excludes infra files for

--- a/internal/resolve/resolver_test.go
+++ b/internal/resolve/resolver_test.go
@@ -155,10 +155,10 @@ func TestResolveCycleDetection(t *testing.T) {
 	}
 }
 
-func TestResolveCollision(t *testing.T) {
+func TestResolveSameNameSkillsAllowed(t *testing.T) {
 	mock := newTestFetcher()
 
-	// Two deps export the same skill name
+	// Two deps export the same skill name — should succeed with namespacing
 	setupDep(mock, "github.com/org/a", "1.0.0", "aaa", "---\nname: shared-skill\n---\n")
 	setupDep(mock, "github.com/org/b", "1.0.0", "bbb", "---\nname: shared-skill\n---\n")
 
@@ -171,15 +171,12 @@ func TestResolveCollision(t *testing.T) {
 		},
 	}
 
-	_, err := resolver.Resolve(m, ResolveOptions{})
-	if err == nil {
-		t.Fatal("Expected collision error")
+	result, err := resolver.Resolve(m, ResolveOptions{})
+	if err != nil {
+		t.Fatalf("Resolve should succeed with same-name skills from different deps, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "collision") {
-		t.Errorf("Error should mention collision, got: %v", err)
-	}
-	if !strings.Contains(err.Error(), "shared-skill") {
-		t.Errorf("Error should mention skill name, got: %v", err)
+	if len(result.Resolved) != 2 {
+		t.Errorf("Expected 2 resolved deps, got %d", len(result.Resolved))
 	}
 }
 


### PR DESCRIPTION
## Summary

Namespace dependency skills by `host/owner/repo` from the dependency URL to allow same-name skills from different dependencies. This resolves the real-world collision where PAW and Anthropic both export `skill-creator` — craft previously hard-errored, now they coexist at distinct paths.

### Design Decision

The namespace uses the full `host/owner/repo` path (e.g., `github.com/lossyrob/phased-agent-workflow`) rather than the user-chosen alias, because:
- **Globally unique** — cannot collide even across git hosts (GitHub, GitLab, self-hosted)
- **Deterministic** — does not change if user re-adds with a different alias
- **Transitive-ready** — every dep has a URL, transitives work automatically
- **Familiar** — mirrors Go module paths

### Install Layout

```
<target>/
├── github.com/lossyrob/phased-agent-workflow/
│   ├── paw-implement/
│   └── skill-creator/         ← from PAW
└── github.com/anthropics/skills/
    ├── pdf/
    └── skill-creator/         ← from Anthropic — no conflict
```

## Changes

### Core Install (internal/cli/install.go)
- collectSkillFiles() prefixes map keys with parsed.PackageIdentity() + "/", producing composite keys like github.com/org/repo/skillName
- verifyIntegrity() uses same composite keys; errors on ParseDepURL failure instead of silently skipping (SoT review fix)

### Resolver (internal/resolve/resolver.go)
- Removed detectCollisions() function and its Phase 5 call — namespacing makes cross-dep collisions structurally impossible

### Remove (internal/cli/remove.go)
- All skills from a removed dep are now treated as orphaned — with namespaced paths, each dep's skills have unique disk paths regardless of name overlap (SoT review caught a critical bug in the original orphan detection logic)
- Added cleanEmptyParents() helper to remove empty host/owner/repo/ ancestor directories after skill removal
- ParseDepURL failure warns user instead of silently falling back to flat path

### Installer (internal/install/installer.go)
- **No signature changes** — composite keys work naturally via filepath.Join creating nested directories
- Updated doc comment

## Testing

| Test | What It Covers |
|------|---------------|
| TestInstallCompositeKeys | Two same-name skills install at different namespace paths |
| TestCollectSkillFiles_SameNameDifferentDeps | Core PAW + Anthropic skill-creator scenario |
| TestCollectSkillFiles_NonGitHubHost | gitlab.example.io namespace paths (SC-005) |
| TestResolveSameNameSkillsAllowed | Resolver accepts same-name skills (replaces collision error test) |
| TestCleanEmptyParents x 3 | Full cleanup, stops at non-empty, stops at root |
| TestRunRemove_SharedSkillRetained | Verifies dep-a same-name skill IS removed under namespacing |
| All existing tests | Updated for namespaced key expectations |

All 15 packages pass (go test ./... -count=1).

## Review

Society of Thought final review with 5 specialists across 4 models:

| Specialist | Model | Findings | Status |
|-----------|-------|----------|--------|
| Correctness | GPT 5.2 | Orphan detection bug — bare names vs namespaced paths | Fixed |
| Security | Gemini 3 Pro | Same orphan bug + integrity silent skip | Fixed |
| Edge Cases | Opus 4.6 | Same + ParseDepURL fallback in remove | Fixed |
| Testing | Sonnet 4.5 | Missing cleanEmptyParents + non-GitHub tests | Added |
| Architecture | Sonnet 4 | Composite key pragmatic, acceptable | Noted |

## Breaking Changes

None. No existing craft users to migrate.

## Follow-up

- #27 — Alias symlinks for shorter skill-to-skill references

## Artifacts

- [Spec.md](.paw/work/namespaced-skill-install/Spec.md) — Feature specification with user stories and acceptance criteria
- [WorkShaping.md](.paw/work/namespaced-skill-install/WorkShaping.md) — Design decisions and rationale
- [SoT Reviews](.paw/work/namespaced-skill-install/reviews/) — 5 specialist review reports

---

Generated with [PAW](https://github.com/lossyrob/phased-agent-workflow)
