### PR TITLE
Consumer Flow & Global Skills Management

### DIFF
--- a/.paw/work/consumer-flow-global-skills/CodeResearch.md
+++ b/.paw/work/consumer-flow-global-skills/CodeResearch.md
@@ -1,0 +1,279 @@
+---
+date: 2026-03-09T18:00:00Z
+git_commit: 4272bcbb15de8a34001ff2f201399a67893eb3ae
+branch: feature/consumer-flow-global-skills
+repository: erdemtuna/craft
+topic: "Consumer Flow & Global Skills Management — Implementation Map"
+tags: [research, codebase, cli, manifest, install, agent, global]
+status: complete
+last_updated: 2026-03-09
+---
+
+# Research: Consumer Flow & Global Skills Management
+
+## Research Question
+
+Where and how do the existing CLI commands, manifest/pinfile types, installer, agent detection, and resolver work? What must change to support `craft get`, `--global` flag, and `forge/` vendoring?
+
+## Summary
+
+The craft codebase is well-structured with clear separation: CLI commands in `internal/cli/`, core types in `internal/manifest/` and `internal/pinfile/`, resolution in `internal/resolve/`, installation in `internal/install/`, and agent detection in `internal/agent/`. Key reusable components for the new features include `resolveInstallTargets()`, `collectSkillFiles()`, `verifyIntegrity()`, the `Resolver`, and `Install()`. The main constraint is that `manifest.Validate()` requires non-empty `Skills`, which must be relaxed for global manifests. All commands load manifests independently from the current working directory — a new code path is needed to load from `~/.craft/` when `-g` is set.
+
+## Documentation System
+
+- **Framework**: Plain markdown (no doc site framework)
+- **Docs Directory**: N/A — docs are in README.md and CONTRIBUTING.md at repo root
+- **Navigation Config**: N/A
+- **Style Conventions**: Concise sections with code examples, tabular comparisons, emoji-free
+- **Build Command**: N/A
+- **Standard Files**: `README.md` (comprehensive user docs), `CONTRIBUTING.md` (dev guide), `CODE_OF_CONDUCT.md`, `LICENSE`
+
+## Verification Commands
+
+- **Test Command**: `task test` → `go test -race ./...`
+- **Lint Command**: `task lint` → `golangci-lint run`
+- **Build Command**: `task build` → `go build` with ldflags version injection
+- **Type Check**: `task vet` → `go vet ./...`
+- **Full CI**: `task ci` → fmt:check → vet → lint → vuln → test → build
+
+## Detailed Findings
+
+### CLI Command Registration
+
+Root command defined at `internal/cli/root.go:10-16`. All 11 subcommands registered in `init()` at lines 21-31. Single global flag `--verbose/-v` registered as `PersistentFlags` at line 19 via `verbose.go:12`.
+
+Each command follows the pattern: cobra `Command` struct with `RunE` function, flags registered in command-local `init()`. No shared command factory — each file is self-contained.
+
+### Manifest Loading Patterns
+
+Commands load manifests independently — no shared `loadManifest()` function:
+
+- `add.go:76` — `manifest.ParseFile()` direct call
+- `install.go:49` — `manifest.ParseFile()` direct call
+- `update.go:50` — `manifest.ParseFile()` direct call
+- `remove.go:41` — `manifest.ParseFile()` direct call
+- `helpers.go:16-42` — `requireManifestAndPinfile()` shared helper loads both manifest and pinfile (used by `validate`, `list`, `tree`)
+
+All paths resolve from current working directory. For `-g` support, a new path resolution mechanism is needed that reads from `~/.craft/` instead.
+
+### Manifest Type & Validation
+
+`internal/manifest/types.go:8-26` — Manifest struct:
+- **Required (no omitempty)**: `SchemaVersion` (int), `Name` (string), `Skills` ([]string)
+- **Optional (omitempty)**: `Description`, `License`, `Dependencies`, `Metadata`
+
+`internal/manifest/validate.go:19-49` — Validation rules:
+- `SchemaVersion` must be exactly `1` (line 23-25)
+- `Name` required, must match `^[a-z][a-z0-9]*(-[a-z0-9]+)*$` (lines 28-34)
+- **`Skills` must be non-empty** (line 37-39: "must contain at least one skill path") — **this blocks global manifests with no skills**
+- `Dependencies` URLs validated if present (lines 42-46)
+
+`internal/manifest/write.go:14-46` — Deterministic YAML serialization with hardcoded field ordering. Empty Skills serialized as empty sequence.
+
+`internal/manifest/parse.go:13-25` — `Parse(r io.Reader)` unmarshals YAML. `ParseFile(path)` at lines 28-36 wraps with file I/O.
+
+### Pinfile Type
+
+`internal/pinfile/types.go:8-35` — Pinfile struct:
+- `PinVersion` (int), `Resolved` (map[string]ResolvedEntry)
+- ResolvedEntry: `Commit`, `RefType` (omitempty, defaults "tag"), `Integrity`, `Source` (omitempty), `Skills`, `SkillPaths` (omitempty)
+
+`internal/pinfile/parse.go:12-33` — Parse with auto-default of empty `RefType` to `"tag"`.
+`internal/pinfile/write.go:14-87` — Deterministic serialization sorted by URL key.
+
+### Dependency URL Parsing
+
+`internal/resolve/depurl.go:40-63` — DepURL struct: `Raw`, `Host`, `Org`, `Repo`, `Version`, `Ref`, `RefType`.
+
+`ParseDepURL()` at line 72 — requires `@` separator and non-empty ref. Three ref types:
+- Tag: `@vMAJOR.MINOR.PATCH`
+- Commit: `@<hex7-64>`
+- Branch: `@branch:<name>`
+
+`PackageIdentity()` at line 120 returns `host/org/repo` — used as namespace prefix for skill paths.
+
+### Resolver
+
+`internal/resolve/resolver.go:24-31` — `Resolver` wraps `GitFetcher`.
+
+`Resolve()` at line 53 — takes `Manifest` + `ResolveOptions` (ExistingPinfile, ForceResolve map). Phases: collect deps recursively → cycle detection → MVS selection → resolve commits → build pinfile.
+
+Existing pinfile reuse at lines 332-341: tags and commits reused unless in `ForceResolve`; branches always re-resolved.
+
+`collectDeps()` at line 260 — recursive with `maxResolutionDepth=20`, `maxTotalDeps=200`.
+
+### Installer
+
+`internal/install/installer.go:17-88` — `Install(target string, skills map[string]map[string][]byte)`:
+- Atomic staging: writes to `.staging` dir, then renames
+- Path traversal protection at lines 33 and 55
+- Permissions: dirs `0o700`, files `0o644`
+
+This function is target-agnostic — works for both agent directories and `forge/`. No changes needed to the installer itself.
+
+### Agent Detection
+
+`internal/agent/detect.go:48-67` — `Detect(homeDir)` returns single agent or error.
+`internal/agent/detect.go:71-78` — `DetectAll(homeDir)` returns all agents (no error).
+
+Detection markers at lines 85-103:
+- ClaudeCode: `~/.claude/` → `~/.claude/skills/`
+- Copilot: `~/.copilot/` → `~/.copilot/skills/`
+
+Interactive prompt in `internal/cli/install.go:185-217` — `promptAgentChoice()` shows numbered menu, supports "Both" option.
+
+### Install Command Pipeline
+
+`internal/cli/install.go:40-139` — `runInstall()` flow:
+1. Load manifest (line 49)
+2. Load existing pinfile (line 63-67)
+3. Create fetcher (line 70-73)
+4. Resolve (line 76-85)
+5. Dry-run check (line 88-92)
+6. Write pinfile atomically (line 95)
+7. Resolve install targets (line 100)
+8. Collect skill files (line 106)
+9. Verify integrity (line 113)
+10. Install to targets (line 119-125)
+
+`resolveInstallTargets()` at line 147 — handles `--target` override, single/multi agent, TTY prompt.
+`collectSkillFiles()` at line 245 — fetches skill files, returns `map[compositeKey]map[filename][]byte`.
+`verifyIntegrity()` at line 296 — compares computed digests against pinfile entries.
+`newFetcher()` at line 343 — creates `GoGitFetcher` with default cache at `~/.craft/cache/`.
+
+### Add Command
+
+`internal/cli/add.go:19-32` — `add [alias] <url>`, 1-2 args.
+Flags: `--install` (line 35), `--target` (line 36).
+
+Alias derivation at line 65-67: `alias = parsed.Repo` if not provided.
+
+`--install` flow at lines 161-185: writes pinfile → resolves targets → collects files → installs. This currently installs to agent dirs — must change to vendor to `forge/`.
+
+### Remove Command & Cleanup
+
+`internal/cli/remove.go:31-150` — `runRemove()`:
+1. Load manifest, validate alias exists (lines 32-54)
+2. Extract orphaned skills from pinfile (lines 56-66)
+3. Delete from manifest + write atomically (lines 68-76)
+4. Delete from pinfile + write atomically (lines 78-86)
+5. Cleanup: delete skill dirs from install targets with path traversal protection (lines 92-146)
+
+`cleanEmptyParents()` at lines 152-169 — walks up directory tree removing empty dirs, stops at root boundary.
+
+Remove currently cleans from agent install targets — for `-g`, it would clean from agent dirs using global manifest/pinfile.
+
+### Update Command
+
+`internal/cli/update.go:24-34` — `update [alias]` with `--target` and `--dry-run`.
+Main loop at lines 87-149: commits skipped, branches re-resolve HEAD, tags check for latest semver.
+Post-update: force-resolves, writes manifest+pinfile atomically, installs (lines 162-219).
+
+### List Command
+
+`internal/cli/list.go:15-21` — `list` with `--detailed`.
+Loads via `requireManifestAndPinfile()`. Builds alias lookup, sorts alphabetically, outputs via tabwriter.
+
+### Tree Command
+
+`internal/cli/tree.go:11-17` — `tree`, no flags.
+Loads via `requireManifestAndPinfile()`. Extracts local skills + deps, delegates to `ui.RenderTree()`.
+
+### Validate Command
+
+`internal/cli/validate.go:13-48` — `validate`, no flags.
+Creates `validate.Runner` and executes. Checks: schema, skill paths, frontmatter, dep URLs, pinfile consistency, name collisions.
+
+### Outdated Command
+
+`internal/cli/outdated.go:15-21` — `outdated`, no flags.
+Loads via `requireManifestAndPinfile()`. Skips commit/branch deps, checks tags for newer semver. Exit code 1 if updates found.
+
+### Atomic Write Infrastructure
+
+`internal/cli/atomic.go:11-31` — `writeAtomic(path, writeFn)` writes to `.tmp`, renames atomically.
+`writePinfileAtomic()` at `install.go:141-145`.
+`writeManifestAtomic()` at `update.go:227-231`.
+
+### Cache Infrastructure
+
+`internal/fetch/cache.go:29` — `DefaultCacheRoot()` returns `~/.craft/cache/`.
+Cache paths use SHA-256 hash of normalized URL for collision resistance.
+
+### Testing Patterns
+
+Test helpers: `testChdir()`, `testWriteFile()`, `testMkdirAll()` — create temp dirs, change cwd, cleanup on test end.
+
+Mock fetcher: `fetch.NewMockFetcher()` used in unit tests for offline resolution.
+
+Test execution pattern: `rootCmd.SetArgs()` + `rootCmd.SetOut/SetErr()` + `Execute()` for CLI integration tests.
+
+36 total test files. Key test files: `install_test.go` (23 tests), `list_test.go` (10 tests), `outdated_test.go` (8 tests).
+
+Fixtures in `testdata/`: `manifests/`, `pinfiles/`, `packages/` (full package structures), `skills/` (individual SKILL.md files).
+
+## Code References
+
+- `internal/cli/root.go:10-31` — Root command and registration
+- `internal/cli/root.go:19` — Verbose persistent flag (model for `-g`)
+- `internal/cli/verbose.go:12` — Verbose flag variable
+- `internal/cli/helpers.go:16-42` — `requireManifestAndPinfile()` shared loader
+- `internal/cli/helpers.go:44-66` — `printDryRunSummary()`
+- `internal/cli/atomic.go:11-31` — `writeAtomic()` generic helper
+- `internal/cli/add.go:19-188` — Add command full implementation
+- `internal/cli/add.go:65-67` — Alias auto-derivation
+- `internal/cli/add.go:161-185` — `--install` flow
+- `internal/cli/install.go:27-139` — Install command full implementation
+- `internal/cli/install.go:141-145` — `writePinfileAtomic()`
+- `internal/cli/install.go:147-183` — `resolveInstallTargets()`
+- `internal/cli/install.go:185-217` — `promptAgentChoice()`
+- `internal/cli/install.go:245-291` — `collectSkillFiles()`
+- `internal/cli/install.go:296-333` — `verifyIntegrity()`
+- `internal/cli/install.go:343-353` — `newFetcher()`
+- `internal/cli/remove.go:31-150` — Remove command with cleanup
+- `internal/cli/remove.go:152-169` — `cleanEmptyParents()`
+- `internal/cli/update.go:24-224` — Update command
+- `internal/cli/update.go:227-231` — `writeManifestAtomic()`
+- `internal/cli/list.go:15-106` — List command
+- `internal/cli/tree.go:11-69` — Tree command
+- `internal/cli/validate.go:13-48` — Validate command
+- `internal/cli/outdated.go:15-204` — Outdated command
+- `internal/manifest/types.go:8-26` — Manifest struct
+- `internal/manifest/validate.go:19-49` — Validation rules (Skills non-empty at line 37)
+- `internal/manifest/parse.go:13-36` — Parse/ParseFile
+- `internal/manifest/write.go:14-46` — Write with field ordering
+- `internal/pinfile/types.go:8-35` — Pinfile/ResolvedEntry structs
+- `internal/pinfile/parse.go:12-44` — Parse with RefType default
+- `internal/pinfile/write.go:14-87` — Write sorted by URL
+- `internal/resolve/resolver.go:24-31` — Resolver type
+- `internal/resolve/resolver.go:34-50` — ResolveOptions/ResolveResult
+- `internal/resolve/resolver.go:53-257` — Resolve() main function
+- `internal/resolve/depurl.go:40-63` — DepURL struct
+- `internal/resolve/depurl.go:72` — ParseDepURL()
+- `internal/resolve/depurl.go:120` — PackageIdentity()
+- `internal/install/installer.go:17-88` — Install() atomic skill writer
+- `internal/agent/detect.go:48-67` — Detect() single agent
+- `internal/agent/detect.go:71-78` — DetectAll() all agents
+- `internal/agent/detect.go:85-103` — Detection markers
+- `internal/fetch/cache.go:29` — DefaultCacheRoot() → `~/.craft/cache/`
+- `Taskfile.yml:21-24` — Test command
+- `Taskfile.yml:49-52` — Lint command
+- `Taskfile.yml:59-67` — CI pipeline
+
+## Architecture Documentation
+
+**Command Pattern**: Each CLI command is a self-contained file with cobra Command definition, init() for flags, and RunE function. No command factory or base class.
+
+**Manifest Loading**: Commands independently call `manifest.ParseFile()` from cwd, or use `requireManifestAndPinfile()` helper. Path is always `filepath.Join(cwd, "craft.yaml")`.
+
+**Atomic Operations**: All file writes use temp-file-then-rename pattern via `writeAtomic()`. Install uses staging directories with atomic swap.
+
+**Resolution**: MVS (Minimum Version Selection) algorithm. Existing pins reused unless forced. Branch deps always re-resolved. Max depth 20, max total deps 200.
+
+**Install Pipeline**: Resolve → write pinfile → detect agent → collect files → verify integrity → atomic install. Target-agnostic — `Install()` accepts any directory path.
+
+**Global Flag Model**: `--verbose/-v` is the only existing persistent flag. Defined as package-level var in `verbose.go`, registered as `PersistentFlags` in `root.go`. This is the model for adding `--global/-g`.
+
+## Open Questions
+
+None — research is comprehensive for the Spec requirements.

--- a/.paw/work/consumer-flow-global-skills/ImplementationPlan.md
+++ b/.paw/work/consumer-flow-global-skills/ImplementationPlan.md
@@ -1,0 +1,192 @@
+# Consumer Flow & Global Skills Management — Implementation Plan
+
+## Overview
+
+Implement a consumer-friendly skill installation flow for craft. This adds `craft get` as a one-command entry point for consumers, introduces global skill state at `~/.craft/`, adds a `--global/-g` flag to existing commands, and changes `craft install` to vendor dependencies into a project-local `forge/` directory instead of writing to agent directories.
+
+## Current State Analysis
+
+- All commands assume project-scoped manifest at `./craft.yaml` — no global concept exists
+- `craft install` writes directly to agent directories (`~/.claude/skills/`, `~/.copilot/skills/`)
+- `manifest.Validate()` requires non-empty `Skills` slice (line 37 of `validate.go`) — blocks global manifests
+- `~/.craft/cache/` already exists for git cache — global state directory partially in place
+- Agent detection, resolution, integrity verification, and atomic installation are all reusable
+- `--verbose/-v` is the only persistent flag — model for adding `--global/-g`
+- `writeManifestAtomic()` and `writePinfileAtomic()` provide atomic write infrastructure
+
+## Desired End State
+
+- Consumers can run `craft get github.com/org/repo@v1.0.0` with no prior setup and have skills installed to their agent
+- Global state tracked at `~/.craft/craft.yaml` + `~/.craft/craft.pin.yaml`, managed via `-g` flag on existing commands
+- `craft install` vendors to `forge/` (gitignored), never writes to agent directories
+- `craft add --install` triggers forge vendoring
+- All existing commands (`list`, `update`, `remove`, `install`, `tree`, `validate`, `outdated`) work with `-g` flag on global state
+- `craft remove -g` uninstalls skill files from agent directories
+- All changes pass existing tests + new tests, lint, and vet
+
+## What We're NOT Doing
+
+- No changes to `craft init` (remains author-only)
+- No central registry or search/browse functionality
+- No implicit "latest tag" resolution — version always required
+- No persisting agent choice across invocations
+- No monorepo/subpath support
+- No `craft get` operating on project manifests (always global)
+
+## Phase Status
+- [ ] **Phase 1: Global Infrastructure** — Global flag, path helpers, validation relaxation
+- [ ] **Phase 2: Forge Vendoring** — Change `craft install` and `craft add --install` to vendor to `forge/`
+- [ ] **Phase 3: craft get Command** — New consumer entry point
+- [ ] **Phase 4: Global Flag on Existing Commands** — `-g` support on list, update, remove, install, tree, validate, outdated
+- [ ] **Phase 5: Documentation** — README updates, Docs.md
+
+## Phase Candidates
+<!-- None — all phases defined -->
+
+---
+
+## Phase 1: Global Infrastructure
+
+### Changes Required:
+
+- **`internal/cli/global.go`** (new file): Define `globalFlag` bool variable and `GlobalCraftDir()` helper returning `~/.craft/`. Add `GlobalManifestPath()` and `GlobalPinfilePath()` helpers. Register `--global/-g` as `PersistentFlags` on `rootCmd` (following `verbose.go` pattern).
+
+- **`internal/cli/root.go`**: No structural changes needed — flag registration happens in `global.go`'s `init()` via `rootCmd.PersistentFlags().BoolVarP()`.
+
+- **`internal/cli/helpers.go`**: Add `loadManifestForScope()` and `loadManifestAndPinfileForScope()` helpers. When `globalFlag` is true, resolve paths from `GlobalCraftDir()` instead of cwd. When global manifest doesn't exist, return a descriptive error suggesting `craft get`.
+
+- **`internal/manifest/validate.go`**: Add `ValidateGlobal(m *Manifest) []error` that skips the Skills non-empty check (line 37-39). Alternatively, add an `Options` struct to `Validate()` with a `AllowEmptySkills` bool. The existing `Validate()` signature and behavior must remain unchanged for project manifests.
+
+- **`internal/cli/global_test.go`** (new file): Test `GlobalCraftDir()` path construction, `GlobalManifestPath()`, `GlobalPinfilePath()`. Test `loadManifestForScope()` returns global or project paths based on flag. Test validation allows empty Skills for global manifests.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Tests pass: `task test`
+- [ ] Lint/typecheck: `task lint && task vet`
+
+#### Manual Verification:
+- [ ] `--global` and `-g` flags appear in help output for all commands
+- [ ] `GlobalCraftDir()` correctly resolves to `$HOME/.craft/`
+
+---
+
+## Phase 2: Forge Vendoring
+
+### Changes Required:
+
+- **`internal/cli/install.go`**: Modify `runInstall()` to branch on `globalFlag`:
+  - When `!globalFlag` (project scope): Replace `resolveInstallTargets()` call with forge directory path (`filepath.Join(cwd, "forge")`). Reuse existing `collectSkillFiles()` → `verifyIntegrity()` → `installlib.Install(forgePath, skills)` pipeline. Add `.gitignore` auto-update logic after successful install.
+  - When `globalFlag`: Keep current behavior (resolve targets to agent dirs) — this becomes `craft install -g`.
+
+- **`internal/cli/install.go`**: Add `ensureGitignore(root, entry)` function. Opens `.gitignore`, checks if `forge/` entry exists, appends if not. Creates `.gitignore` if missing. Uses `os.OpenFile` with append mode.
+
+- **`internal/cli/add.go`**: Modify `--install` flow (lines 161-185) to use forge path instead of `resolveInstallTargets()` when `!globalFlag`. Same change: install to `filepath.Join(cwd, "forge")`.
+
+- **`internal/cli/install_test.go`**: Add tests for forge vendoring: verify files land in `forge/`, verify `.gitignore` is updated, verify no agent directory writes in project scope. Test `install -g` still writes to agent directories.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Tests pass: `task test`
+- [ ] Lint/typecheck: `task lint && task vet`
+
+#### Manual Verification:
+- [ ] `craft install` in a project creates `forge/` with vendored skill files
+- [ ] `forge/` appears in `.gitignore` after first install
+- [ ] No files written to `~/.claude/skills/` or `~/.copilot/skills/` during project install
+
+---
+
+## Phase 3: craft get Command
+
+### Changes Required:
+
+- **`internal/cli/get.go`** (new file): New cobra command `get [alias] <url> [url...]`. Accepts 1+ positional args (parsed as optional alias + URLs). Flags: `--dry-run`, `--target`. Core flow:
+  1. Parse each URL via `resolve.ParseDepURL()`
+  2. Load or create global manifest from `GlobalManifestPath()`
+  3. For each dep: check if already installed, prompt if version differs
+  4. Add all deps to global manifest
+  5. Resolve full tree via `resolver.Resolve()`
+  6. If `--dry-run`: print summary, exit
+  7. Write global manifest and pinfile atomically
+  8. Resolve agent install targets (reuse `resolveInstallTargets()`)
+  9. Collect files, verify integrity, install to agent dirs
+
+- **`internal/cli/get.go`**: Auto-create global manifest function. When `~/.craft/craft.yaml` doesn't exist, create with `schema_version: 1`, `name: global`, empty skills, and the new dependency. Ensure `~/.craft/` directory exists via `os.MkdirAll`.
+
+- **`internal/cli/get.go`**: Prompt-on-existing logic. When dependency alias already exists with different URL/version, prompt user via stdin (if TTY) whether to update. If not TTY, error.
+
+- **`internal/cli/root.go`**: Register `getCmd` in `init()`.
+
+- **`internal/cli/get_test.go`** (new file): Tests for: single URL install, multiple URLs, alias derivation, alias override, already-installed prompt, dry-run mode, missing ref error, no agent error, global manifest auto-creation.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Tests pass: `task test`
+- [ ] Lint/typecheck: `task lint && task vet`
+
+#### Manual Verification:
+- [ ] `craft get github.com/org/repo@v1.0.0` creates `~/.craft/craft.yaml`, `~/.craft/craft.pin.yaml`, and installs skills to agent directory
+- [ ] Running `craft get` again with same URL reports "already installed"
+- [ ] Running `craft get` with different version prompts to update
+- [ ] `craft get --dry-run` shows preview without writing files
+- [ ] `craft get url1 url2` installs both
+
+---
+
+## Phase 4: Global Flag on Existing Commands
+
+### Changes Required:
+
+- **`internal/cli/list.go`**: When `globalFlag`, use `loadManifestAndPinfileForScope()` to load from `~/.craft/`. Same output format. Add "No global skills installed" message if global manifest doesn't exist.
+
+- **`internal/cli/tree.go`**: When `globalFlag`, load from `~/.craft/`. Use `name: global` as root. No local skills section (global manifests have no skills).
+
+- **`internal/cli/validate.go`**: When `globalFlag`, validate global manifest with `ValidateGlobal()`. Check pinfile consistency against global state.
+
+- **`internal/cli/outdated.go`**: When `globalFlag`, load from `~/.craft/`. Same logic for checking newer versions.
+
+- **`internal/cli/update.go`**: When `globalFlag`, load from `~/.craft/`. After resolution, install to agent directories (not forge). Use `resolveInstallTargets()` for agent detection. Write updated global manifest and pinfile.
+
+- **`internal/cli/remove.go`**: When `globalFlag`, load from `~/.craft/`. After removing from global manifest/pinfile, clean up skill files from agent directories. Reuse existing `cleanEmptyParents()` logic. Use `resolveInstallTargets()` or `--target` for cleanup paths.
+
+- **`internal/cli/install.go`**: `install -g` path already handled in Phase 2 (when `globalFlag`, use agent targets instead of forge).
+
+- **Tests across `*_test.go`**: Add `-g` flag tests for each command. Test global manifest loading, error on missing global state, correct output.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Tests pass: `task test`
+- [ ] Lint/typecheck: `task lint && task vet`
+
+#### Manual Verification:
+- [ ] `craft list -g` shows globally installed dependencies
+- [ ] `craft tree -g` shows global dependency tree
+- [ ] `craft update -g` updates global dependencies and reinstalls to agent
+- [ ] `craft remove -g <alias>` removes from global state and deletes skill files from agent
+- [ ] `craft validate -g` validates global manifest and pinfile
+- [ ] `craft outdated -g` reports outdated global dependencies
+- [ ] `craft install -g` reinstalls global deps to agent directories
+
+---
+
+## Phase 5: Documentation
+
+### Changes Required:
+
+- **`.paw/work/consumer-flow-global-skills/Docs.md`**: Technical reference capturing all implementation details, load `paw-docs-guidance` for template.
+- **`README.md`**: Add consumer workflow section (`craft get`), document `forge/` vendoring, document `-g` flag, update command reference table.
+
+### Success Criteria:
+- [ ] Content accurate, style consistent with existing README
+- [ ] All new commands and flags documented
+
+---
+
+## References
+- Spec: `.paw/work/consumer-flow-global-skills/Spec.md`
+- Research: `.paw/work/consumer-flow-global-skills/CodeResearch.md`
+- WorkShaping: `.paw/work/WorkShaping-consumer-flow.md`

--- a/.paw/work/consumer-flow-global-skills/Spec.md
+++ b/.paw/work/consumer-flow-global-skills/Spec.md
@@ -1,0 +1,188 @@
+# Feature Specification: Consumer Flow & Global Skills Management
+
+**Branch**: feature/consumer-flow-global-skills  |  **Created**: 2026-03-09  |  **Status**: Draft
+**Input Brief**: Enable pure consumers to install skills from any repo with a single command (`craft get`), add global scope (`-g`) to existing commands, and change project installs to vendor into `forge/` instead of writing to agent directories.
+
+## Overview
+
+Today, developers who discover a useful set of AI agent skills on GitHub face an awkward path to install them. They must first run `craft init` to create a skill package manifest — even though they aren't authoring skills — then `craft add` the dependency, then `craft install`. This three-step author workflow imposes unnecessary ceremony on someone who simply wants skills available in their Claude Code or GitHub Copilot agent.
+
+The manual alternative — cloning a repo and copying files to `~/.claude/skills/` — is faster but sacrifices everything craft offers: version pinning, integrity verification, transitive dependency resolution, and an update path. Users shouldn't have to choose between convenience and safety.
+
+This feature introduces a clear separation between two personas. **Consumers** get a single-command entry point (`craft get`) that fetches, resolves, verifies, and installs skills globally to their agent. **Authors** continue using `craft init`, `craft add`, and `craft install` for package development, but `craft install` now vendors dependencies into a project-local `forge/` directory instead of writing directly to agent directories. Both personas manage their installed skills with the same verbs (`list`, `update`, `remove`, etc.) — distinguished only by a `--global` / `-g` flag.
+
+The result is a tool that meets users where they are: consumers get a near-zero-ceremony install experience with full craft guarantees, while authors get a clean separation between their project's dependency tree and their global agent setup.
+
+## Objectives
+
+- Enable consumers to install skills from any repo in a single command without creating a project or running `craft init`
+- Introduce global skill state (`~/.craft/craft.yaml` + `~/.craft/craft.pin.yaml`) so consumers can track, update, and remove their installed skills
+- Separate project-scoped dependency installation (`forge/`) from global agent installation to prevent conflicts between the two contexts
+- Provide consistent lifecycle management across both scopes using the same command verbs with a `-g` flag
+- Maintain craft's core guarantees (version pinning, integrity verification, transitive resolution) in both consumer and author workflows
+
+## User Scenarios & Testing
+
+### User Story P1 – Consumer Installs Skills Globally
+
+Narrative: A developer finds a skill package on GitHub. They run a single command to install its skills into their AI agent. The skills appear in their agent immediately, and craft tracks what was installed for future updates.
+
+Independent Test: Run `craft get github.com/alice/skills@v1.0.0` and verify skills appear in the agent's skill directory.
+
+Acceptance Scenarios:
+1. Given a valid dependency URL with a tag ref, When the user runs `craft get <url>`, Then skills are installed to the detected agent directory, and `~/.craft/craft.yaml` and `~/.craft/craft.pin.yaml` are created/updated with the new dependency.
+2. Given no `~/.craft/craft.yaml` exists, When the user runs `craft get <url>` for the first time, Then the global manifest is auto-created with `schema_version: 1`, `name: global`, and the dependency entry.
+3. Given the dependency has transitive dependencies, When the user runs `craft get <url>`, Then all transitive dependencies are resolved, pinned, and their skills installed.
+4. Given the dependency is already globally installed at a different version, When the user runs `craft get <url>@<new-version>`, Then the user is prompted whether they want to update, and if confirmed the version is updated in manifest, pinfile, and agent directory.
+5. Given no agent directory (`~/.claude/` or `~/.copilot/`) exists, When the user runs `craft get`, Then an error is shown: "No agent detected. Do you have Claude Code or GitHub Copilot installed?"
+6. Given multiple agent directories exist and stdin is a TTY, When the user runs `craft get`, Then the user is prompted to choose one agent, all agents, or cancel.
+7. Given multiple agent directories exist and stdin is not a TTY, When the user runs `craft get`, Then an error is shown suggesting `--target <path>`.
+
+### User Story P2 – Consumer Manages Global Skills
+
+Narrative: A developer who has previously installed skills via `craft get` wants to list what they have, update to newer versions, or remove skills they no longer need.
+
+Independent Test: Run `craft list -g` after installing skills globally and verify the installed dependencies are listed.
+
+Acceptance Scenarios:
+1. Given skills are globally installed, When the user runs `craft list -g`, Then all globally tracked dependencies are listed with aliases and versions.
+2. Given skills are globally installed, When the user runs `craft update -g`, Then all updatable dependencies are checked for newer versions and updated in global manifest, pinfile, and agent directory.
+3. Given skills are globally installed, When the user runs `craft update -g <alias>`, Then only the specified dependency is updated.
+4. Given a dependency is globally installed, When the user runs `craft remove -g <alias>`, Then the dependency is removed from the global manifest and pinfile, and its skill files are deleted from the agent directory.
+5. Given skills are globally installed, When the user runs `craft tree -g`, Then the global dependency tree is displayed.
+6. Given skills are globally installed, When the user runs `craft validate -g`, Then the global manifest and pinfile are validated.
+7. Given skills are globally installed, When the user runs `craft outdated -g`, Then outdated global dependencies are reported.
+8. Given skills are globally installed, When the user runs `craft install -g`, Then all globally tracked dependencies are re-installed to agent directories from pinned state.
+
+### User Story P3 – Author Vendors Dependencies to `forge/`
+
+Narrative: A skill author runs `craft install` in their project. Dependencies are vendored into a local `forge/` directory for reference and development, rather than being installed to the global agent directory.
+
+Independent Test: Run `craft install` in a project with dependencies and verify skill files appear in `forge/` and not in `~/.claude/skills/`.
+
+Acceptance Scenarios:
+1. Given a project with dependencies in `craft.yaml`, When the user runs `craft install`, Then dependencies are resolved, `craft.pin.yaml` is written, and dependency skill files are written to `forge/` in the project root.
+2. Given `forge/` is not in `.gitignore`, When the user runs `craft install`, Then `forge/` is auto-added to `.gitignore`.
+3. Given a project with dependencies, When the user runs `craft add --install <url>`, Then the dependency is added to `craft.yaml` and `craft install` is triggered, vendoring to `forge/`.
+4. Given a project with dependencies, When the user runs `craft install`, Then no files are written to `~/.claude/skills/` or `~/.copilot/skills/`.
+
+### User Story P4 – Consumer Uses `craft get` with Multiple URLs
+
+Narrative: A developer wants to install skills from several repos at once, similar to `go install pkg1@v1 pkg2@v2`.
+
+Independent Test: Run `craft get <url1> <url2>` and verify both packages' skills are installed globally.
+
+Acceptance Scenarios:
+1. Given two valid dependency URLs, When the user runs `craft get <url1> <url2>`, Then both are resolved, pinned, and installed to the agent directory.
+2. Given one valid and one invalid URL, When the user runs `craft get <url1> <invalid>`, Then an error is reported and neither dependency is installed (atomic behavior).
+
+### User Story P5 – Consumer Previews Before Installing
+
+Narrative: A developer wants to see what `craft get` would do before committing to it.
+
+Independent Test: Run `craft get --dry-run <url>` and verify no files are written but a preview is shown.
+
+Acceptance Scenarios:
+1. Given a valid dependency URL, When the user runs `craft get --dry-run <url>`, Then the resolved dependency tree and target agent directory are displayed, but no files are written to disk.
+
+### Edge Cases
+
+- `craft get` with a dependency URL missing `@ref` produces an error with usage hint: "Missing version — use `@vX.Y.Z`, `@branch:<name>`, or `@<commit-sha>`"
+- `craft get` in a directory with a `craft.yaml` still operates on the global manifest (not the project manifest)
+- `craft remove -g` on the last dependency results in an empty global manifest (not deleted)
+- `craft install -g` with no global manifest produces an error: "No global skills installed. Use `craft get` to install skills."
+- `craft install` with no dependencies in project `craft.yaml` skips `forge/` creation
+- `craft get` with the same URL and same version as already installed reports "already installed" and exits cleanly
+
+## Requirements
+
+### Functional Requirements
+
+- FR-001: `craft get [alias] <url>[@ref] [url[@ref]...]` command that resolves, pins, and installs skills to agent directories from global state (Stories: P1, P4, P5)
+- FR-002: Global manifest auto-creation at `~/.craft/craft.yaml` on first `craft get`, with `schema_version: 1`, `name: global`, and empty skills list (Stories: P1)
+- FR-003: Global pinfile at `~/.craft/craft.pin.yaml` tracking pinned commits and SHA-256 integrity digests for globally installed dependencies (Stories: P1)
+- FR-004: `--global` / `-g` flag on `list`, `update`, `remove`, `install`, `tree`, `validate`, and `outdated` commands that redirects them to operate on `~/.craft/craft.yaml` and `~/.craft/craft.pin.yaml` (Stories: P2)
+- FR-005: `craft install` (project scope) vendors resolved dependency skill files to `forge/` directory in the project root instead of agent directories (Stories: P3)
+- FR-006: Auto-add `forge/` to `.gitignore` on first `craft install` if not already present (Stories: P3)
+- FR-007: `craft add --install` triggers vendoring to `forge/` (not agent directory installation) (Stories: P3)
+- FR-008: `craft get` prompts user to confirm update when the dependency is already globally installed at a different version (Stories: P1)
+- FR-009: `craft get` accepts multiple dependency URLs in a single invocation, resolving and installing all atomically (Stories: P4)
+- FR-010: `craft get --dry-run` previews resolution and install targets without writing any files (Stories: P5)
+- FR-011: `craft remove -g` deletes skill files from agent directories and removes the dependency from global manifest and pinfile (Stories: P2)
+- FR-012: Agent detection for global commands — error if none found, auto-select if one, interactive prompt if multiple (TTY), error if multiple (non-TTY) (Stories: P1, P2)
+- FR-013: `--target` flag on `craft get` and `craft install -g` to override agent auto-detection (Stories: P1, P2)
+- FR-014: Alias auto-derivation from repository name for `craft get`, with optional override via positional argument (Stories: P1)
+
+### Key Entities
+
+- **Global Manifest**: `~/.craft/craft.yaml` — tracks globally installed dependencies, auto-created on first `craft get`
+- **Global Pinfile**: `~/.craft/craft.pin.yaml` — pins exact commits and integrity digests for global dependencies
+- **Forge Directory**: `./forge/` — project-local vendored dependency skills, gitignored, reproduced from `craft.pin.yaml`
+- **Agent Directory**: `~/.claude/skills/` or `~/.copilot/skills/` — where agents load skills from, managed exclusively by global commands
+
+### Cross-Cutting / Non-Functional
+
+- All global operations must work without a project `craft.yaml` in the current directory
+- Project operations must not write to agent directories
+- Global operations must not write to project `forge/` directory
+- Agent choice is never persisted — always prompt on multiple detection (use `--target` to skip)
+- `forge/` is always gitignored, never committed
+
+## Success Criteria
+
+- SC-001: A user with no `craft.yaml` in their current directory can run `craft get <url>` and have skills installed to their agent directory within a single command (FR-001, FR-002, FR-003)
+- SC-002: Running `craft list -g`, `craft update -g`, `craft remove -g`, `craft tree -g`, `craft validate -g`, `craft outdated -g`, and `craft install -g` all operate on global state without requiring a project manifest (FR-004)
+- SC-003: Running `craft install` in a project writes dependency files to `forge/` and does not write to any agent directory (FR-005)
+- SC-004: The `forge/` entry appears in `.gitignore` after first `craft install` (FR-006)
+- SC-005: Running `craft get` for an already-installed dependency prompts the user before updating (FR-008)
+- SC-006: Running `craft get url1 url2` installs both atomically — either all succeed or none are written (FR-009)
+- SC-007: Running `craft remove -g <alias>` removes skill files from the agent directory (FR-011)
+
+## Assumptions
+
+- The global manifest default name is `"global"` — this is a sentinel value, not user-configurable
+- `Skills` field in the global manifest is an empty slice — global manifests don't export skills
+- The existing `Manifest` struct and validation accept an empty `Skills` slice for global manifests
+- `forge/` directory structure mirrors the agent install structure: `forge/host/org/repo/skill-name/`
+- The global cache at `~/.craft/cache/` is shared between project and global operations (no duplication)
+- Agent detection logic and `--target` flag are reused as-is from current implementation via `resolveInstallTargets`
+
+## Scope
+
+In Scope:
+- New `craft get` command with all described behaviors
+- `--global` / `-g` flag on `list`, `update`, `remove`, `install`, `tree`, `validate`, `outdated`
+- `craft install` change to vendor to `forge/` instead of agent directories
+- `craft add --install` behavior change to vendor to `forge/`
+- Global manifest and pinfile auto-creation and management at `~/.craft/`
+- Skill file deletion from agent directories on `craft remove -g`
+- Auto-adding `forge/` to `.gitignore`
+- `--dry-run` and `--target` flags on `craft get`
+- Multiple URL support for `craft get`
+
+Out of Scope:
+- Changes to `craft init` (remains author-only, unchanged)
+- Persisting agent choice across invocations
+- Implicit "latest tag" resolution (version/ref always required)
+- Central registry or search functionality
+- `craft get` operating on project manifests (always global)
+- Publishing or pushing skills to remotes
+
+## Dependencies
+
+- Existing `ParseDepURL` logic for URL parsing (unchanged)
+- Existing `resolver.Resolve` for dependency resolution (reused for global context)
+- Existing `agent.Detect` / `agent.DetectAll` for agent discovery (reused)
+- Existing `installlib.Install` for atomic skill file writing (reused for global installs and forge vendoring)
+- Existing `remove.go` cleanup logic for skill file deletion (adapted for global scope)
+
+## Risks & Mitigations
+
+- **Global manifest conflicts with project manifest**: A user might run `craft get` inside a project directory. Risk: confusing which manifest is being operated on. Mitigation: `craft get` always operates on `~/.craft/craft.yaml` regardless of current directory. Document clearly.
+- **`forge/` name collision**: Another tool or convention might use `forge/`. Risk: low, name is distinctive. Mitigation: craft owns the directory and documents it.
+- **Empty `Skills` validation failure**: Current validation may reject manifests with no skills. Risk: global manifest creation fails. Mitigation: ensure validation allows empty skills for global scope.
+- **Uninstall leaves empty directories**: Removing skills may leave orphaned parent directories. Mitigation: clean up empty parent directories during removal (existing logic in `remove.go`).
+
+## References
+
+- WorkShaping: `.paw/work/WorkShaping-consumer-flow.md`

--- a/.paw/work/consumer-flow-global-skills/WorkflowContext.md
+++ b/.paw/work/consumer-flow-global-skills/WorkflowContext.md
@@ -1,0 +1,30 @@
+# WorkflowContext
+
+Work Title: Consumer Flow Global Skills
+Work ID: consumer-flow-global-skills
+Base Branch: main
+Target Branch: feature/consumer-flow-global-skills
+Workflow Mode: full
+Review Strategy: local
+Review Policy: final-pr-only
+Session Policy: continuous
+Final Agent Review: enabled
+Final Review Mode: society-of-thought
+Final Review Interactive: smart
+Final Review Models: none
+Final Review Specialists: all
+Final Review Interaction Mode: parallel
+Final Review Specialist Models: none
+Plan Generation Mode: single-model
+Plan Generation Models: none
+Planning Docs Review: enabled
+Planning Review Mode: single-model
+Planning Review Interactive: smart
+Planning Review Models: none
+Custom Workflow Instructions: none
+Initial Prompt: Consumer flow and global skills management — new `craft get` command, `--global` flag on existing commands, `forge/` vendoring for project installs, global state in `~/.craft/`.
+Issue URL: none
+Remote: origin
+Artifact Lifecycle: commit-and-persist
+Artifact Paths: auto-derived
+Additional Inputs: none

--- a/README.md
+++ b/README.md
@@ -14,7 +14,21 @@ But there's no official way to declare or manage these dependencies. Without pro
 
 craft fixes this. It's a package manager for Agent Skills — think Go modules, but for skills.
 
-## Quick Start: Install Skills
+## Installation
+
+```bash
+go install github.com/erdemtuna/craft/cmd/craft@latest
+```
+
+Or build from source:
+
+```bash
+git clone https://github.com/erdemtuna/craft.git
+cd craft
+go build -o craft ./cmd/craft
+```
+
+## For Consumers: Install & Use Skills
 
 Found a skill package you want to use? One command:
 
@@ -30,21 +44,21 @@ That's it — skills are installed to your AI agent and tracked for updates. No 
 $ craft list -g              # list globally installed skills
 $ craft update -g            # update to newer versions
 $ craft remove -g standards  # uninstall
+$ craft outdated -g          # check for updates
 ```
 
-## How It Works
+## For Developers: Create & Publish Skill Packages
 
-craft borrows directly from Go's dependency model:
+If you're building skill packages — defining dependencies, publishing for others to consume — craft gives you a full dependency management workflow.
 
-| craft | Go | Purpose |
-|-------|-----|---------|
-| `craft.yaml` | `go.mod` | Declare what you export and what you depend on |
-| `craft.pin.yaml` | `go.sum` | Lock exact git commits + SHA-256 integrity digests |
-| `SKILL.md` | package doc | Skill metadata (name, description) |
+**Initialize a new package:**
 
-Dependencies are resolved using **Minimal Version Selection (MVS)**, fetched from git, and cached locally at `~/.craft/cache/`. Every resolved dependency is pinned to an exact commit SHA and verified with a SHA-256 integrity digest — no surprises.
+```bash
+# Auto-discovers SKILL.md files and walks you through setup
+$ craft init
+```
 
-## Example
+### Example
 
 Say your organization has a set of API conventions — naming rules, error response formats, pagination patterns, auth standards. Today these live in a wiki page that nobody reads. You encode them into a `company-standards` skill package so every AI coding agent in the org follows the same rules:
 
@@ -81,9 +95,6 @@ Meanwhile, the docs team's `doc-generator` skill and the infra team's `api-desig
 **Set up and validate:**
 
 ```bash
-# Initialize a new package — auto-discovers SKILL.md files and walks you through setup
-$ craft init
-
 # Validate everything: schema, skill paths, frontmatter, dependency URLs, collision checks
 $ craft validate
 ✓ craft.yaml schema valid
@@ -113,7 +124,7 @@ resolved:
 
 Commit this alongside `craft.yaml`. Anyone who runs `craft install` gets the exact same dependency tree.
 
-## Depending on Repos That Don't Use craft
+### Depending on Repos That Don't Use craft
 
 Not every skill repo has a `craft.yaml` — and that's fine. craft doesn't require upstream repos to adopt it.
 
@@ -129,34 +140,54 @@ dependencies:
 
 The only difference: repos without `craft.yaml` are treated as **leaf dependencies** — craft can't resolve transitive dependencies from them because there's no manifest declaring any. If `legacy-skills` itself depends on other packages, those won't be pulled in automatically. Once the upstream repo adds a `craft.yaml`, transitive resolution kicks in with no changes on your side.
 
-## Installation
+## How It Works
 
-```bash
-go install github.com/erdemtuna/craft/cmd/craft@latest
-```
+craft borrows directly from Go's dependency model:
 
-Or build from source:
+| craft | Go | Purpose |
+|-------|-----|---------|
+| `craft.yaml` | `go.mod` | Declare what you export and what you depend on |
+| `craft.pin.yaml` | `go.sum` | Lock exact git commits + SHA-256 integrity digests |
+| `SKILL.md` | package doc | Skill metadata (name, description) |
 
-```bash
-git clone https://github.com/erdemtuna/craft.git
-cd craft
-go build -o craft ./cmd/craft
-```
+Dependencies are resolved using **Minimal Version Selection (MVS)**, fetched from git, and cached locally at `~/.craft/cache/`. Every resolved dependency is pinned to an exact commit SHA and verified with a SHA-256 integrity digest — no surprises.
 
 ## Commands
+
+### Consumer Commands
+
+No project setup required — these operate on globally installed skills.
 
 | Command | Description |
 |---------|-------------|
 | `craft get [alias] <url> [url...]` | Install skills globally to your AI agent |
+| `craft list -g` | List globally installed skills |
+| `craft update -g [alias]` | Update globally installed skills |
+| `craft remove -g <alias>` | Remove a globally installed skill |
+| `craft outdated -g` | Check for global skill updates |
+| `craft validate -g` | Validate global manifest |
+| `craft tree -g` | Print global dependency tree |
+
+### Developer Commands
+
+Operate on the project manifest (`craft.yaml`) in the current directory.
+
+| Command | Description |
+|---------|-------------|
 | `craft init` | Interactive package setup with skill auto-discovery |
+| `craft add [alias] <url>` | Add a dependency to `craft.yaml` |
 | `craft install` | Resolve, pin, and vendor dependencies to `forge/` |
-| `craft update [alias]` | Update dependencies (re-resolve branches, skip commit pins, bump tags) |
-| `craft add [alias] <url>` | Add a dependency (verify, then update manifest) |
-| `craft remove <alias>` | Remove a dependency and clean up orphaned skills |
-| `craft list` | List resolved dependencies with versions and skill counts |
-| `craft tree` | Print the dependency tree |
-| `craft outdated` | Show available dependency updates |
+| `craft update [alias]` | Update project dependencies (re-resolve branches, skip commit pins, bump tags) |
+| `craft remove <alias>` | Remove a dependency and clean up orphaned skills from `forge/` |
+| `craft list` | List project dependencies with versions and skill counts |
+| `craft tree` | Print project dependency tree |
+| `craft outdated` | Show available project dependency updates |
 | `craft validate` | Run all validation checks (schema, paths, frontmatter, deps, collisions, non-tagged warnings) |
+
+### Shared Commands
+
+| Command | Description |
+|---------|-------------|
 | `craft cache clean` | Remove all cached repositories from `~/.craft/cache/` |
 | `craft version` | Print version and exit |
 
@@ -296,7 +327,7 @@ $ echo $?
 | Flag | Available On | Description |
 |------|-------------|-------------|
 | `--dry-run` | `install`, `update`, `get` | Show what would happen without making any changes |
-| `--target <path>` | `install`, `update`, `remove`, `get` | Override agent auto-detection with a custom install path |
+| `--target <path>` | `get`, `install -g`, `update -g`, `remove` | Override agent auto-detection with a custom install path. Rejected on project-scope `install` and `update` (skills vendor to `forge/`). |
 
 ## Manifest Reference (`craft.yaml`)
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,24 @@ But there's no official way to declare or manage these dependencies. Without pro
 
 craft fixes this. It's a package manager for Agent Skills — think Go modules, but for skills.
 
+## Quick Start: Install Skills
+
+Found a skill package you want to use? One command:
+
+```bash
+$ craft get github.com/acme/company-standards@v2.1.0
+Installed 2 skill(s) from 1 package(s) to /home/user/.claude/skills
+```
+
+That's it — skills are installed to your AI agent and tracked for updates. No project setup needed.
+
+```bash
+# Manage what you've installed
+$ craft list -g              # list globally installed skills
+$ craft update -g            # update to newer versions
+$ craft remove -g standards  # uninstall
+```
+
 ## How It Works
 
 craft borrows directly from Go's dependency model:
@@ -74,11 +92,11 @@ $ craft validate
 ✓ Dependency URLs well-formed
 ✓ No skill name collisions
 
-# Resolve, pin, and install dependencies to your agent's skill directory
+# Resolve, pin, and vendor dependencies to forge/ (project-local)
 $ craft install
 ```
 
-After install, `craft.pin.yaml` locks every dependency to an exact state:
+After install, `craft.pin.yaml` locks every dependency to an exact state, and `forge/` contains the vendored skill files (gitignored, reproducible from the pinfile):
 
 ```yaml
 # craft.pin.yaml (generated — do not edit)
@@ -129,8 +147,9 @@ go build -o craft ./cmd/craft
 
 | Command | Description |
 |---------|-------------|
+| `craft get [alias] <url> [url...]` | Install skills globally to your AI agent |
 | `craft init` | Interactive package setup with skill auto-discovery |
-| `craft install` | Resolve, pin, and install all dependencies |
+| `craft install` | Resolve, pin, and vendor dependencies to `forge/` |
 | `craft update [alias]` | Update dependencies (re-resolve branches, skip commit pins, bump tags) |
 | `craft add [alias] <url>` | Add a dependency (verify, then update manifest) |
 | `craft remove <alias>` | Remove a dependency and clean up orphaned skills |
@@ -140,6 +159,29 @@ go build -o craft ./cmd/craft
 | `craft validate` | Run all validation checks (schema, paths, frontmatter, deps, collisions, non-tagged warnings) |
 | `craft cache clean` | Remove all cached repositories from `~/.craft/cache/` |
 | `craft version` | Print version and exit |
+
+All management commands support `--global` / `-g` to operate on globally installed skills instead of the project manifest.
+
+### `craft get`
+
+Install skills from any repository directly into your AI agent's skill directory. No `craft init` or project setup required.
+
+```bash
+# Install a skill package
+$ craft get github.com/acme/company-standards@v2.1.0
+Installed 2 skill(s) from 1 package(s) to /home/user/.claude/skills
+
+# Install with a custom alias
+$ craft get standards github.com/acme/company-standards@v2.1.0
+
+# Install multiple packages at once
+$ craft get github.com/acme/standards@v2.1.0 github.com/acme/utils@v1.0.0
+
+# Preview what would be installed
+$ craft get --dry-run github.com/acme/standards@v2.1.0
+```
+
+Global state is tracked at `~/.craft/craft.yaml` and `~/.craft/craft.pin.yaml` — auto-created on first use.
 
 ### `craft add`
 
@@ -155,7 +197,7 @@ Added "utility-skills" → github.com/acme/utility-skills@v1.0.0
 # Add with custom alias
 $ craft add utils github.com/acme/utility-skills@v1.0.0
 
-# Add and immediately install
+# Add and immediately vendor to forge/
 $ craft add --install github.com/acme/utility-skills@v1.0.0
 
 # Add a dependency from a branch (for repos without tags)
@@ -247,13 +289,14 @@ $ echo $?
 | Flag | Description |
 |------|-------------|
 | `--verbose`, `-v` | Enable verbose diagnostic output (shows fetches, version comparisons, cache operations) |
+| `--global`, `-g` | Operate on globally installed skills (`~/.craft/`) instead of the project manifest |
 
 ### Operation Flags
 
 | Flag | Available On | Description |
 |------|-------------|-------------|
-| `--dry-run` | `install`, `update` | Show what would happen without making any changes |
-| `--target <path>` | `install`, `update`, `add`, `remove` | Override agent auto-detection with a custom install path |
+| `--dry-run` | `install`, `update`, `get` | Show what would happen without making any changes |
+| `--target <path>` | `install`, `update`, `remove`, `get` | Override agent auto-detection with a custom install path |
 
 ## Manifest Reference (`craft.yaml`)
 
@@ -287,11 +330,10 @@ craft auto-detects your AI agent and installs skills to the correct directory:
 | Claude Code | `~/.claude/` | `~/.claude/skills/` |
 | GitHub Copilot | `~/.copilot/` | `~/.copilot/skills/` |
 
-When both agents are detected, craft prompts you to choose. Use `--target <path>` to override auto-detection:
+When both agents are detected, craft prompts you to choose. Use `--target <path>` to override auto-detection.
 
-```bash
-$ craft install --target ./my-skills
-```
+**Global installs** (`craft get`, `craft install -g`) write to agent skill directories.  
+**Project installs** (`craft install`) vendor to `forge/` in the project root (gitignored).
 
 ## Known Limitations
 

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -32,8 +32,7 @@ The dependency is verified by resolving it before updating the manifest.`,
 }
 
 func init() {
-	addCmd.Flags().BoolVar(&addInstall, "install", false, "Run install after adding the dependency")
-	addCmd.Flags().StringVar(&installTarget, "target", "", "Override agent auto-detection with a custom install path (used with --install)")
+	addCmd.Flags().BoolVar(&addInstall, "install", false, "Run install after adding the dependency (vendors to forge/)")
 }
 
 func runAdd(cmd *cobra.Command, args []string) error {
@@ -157,7 +156,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		cmd.Printf("  branch: %s\n", parsed.Ref)
 	}
 
-	// Optionally run install
+	// Optionally run install (vendor to forge/)
 	if addInstall {
 		// Write pinfile
 		pfPath := filepath.Join(root, "craft.pin.yaml")
@@ -165,23 +164,23 @@ func runAdd(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		targetPaths, err := resolveInstallTargets(installTarget)
-		if err != nil {
-			return err
-		}
+		forgePath := filepath.Join(root, "forge")
 
 		skillFiles, err := collectSkillFiles(fetcher, result)
 		if err != nil {
 			return err
 		}
 
-		for _, targetPath := range targetPaths {
-			if err := installlib.Install(targetPath, skillFiles); err != nil {
-				return fmt.Errorf("installation failed: %w", err)
-			}
+		if err := installlib.Install(forgePath, skillFiles); err != nil {
+			return fmt.Errorf("vendoring failed: %w", err)
 		}
 
-		cmd.Printf("Installed %d skill(s) to %s\n", countSkills(result), strings.Join(targetPaths, ", "))
+		// Auto-add forge/ to .gitignore
+		if err := ensureGitignore(root, "forge/"); err != nil {
+			cmd.PrintErrf("warning: could not update .gitignore: %v\n", err)
+		}
+
+		cmd.Printf("Vendored %d skill(s) to forge/\n", countSkills(result))
 	}
 
 	return nil

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -64,6 +64,9 @@ func runGet(cmd *cobra.Command, args []string) error {
 		if len(args) != 2 {
 			return fmt.Errorf("when providing an alias, exactly one URL must follow\n  usage: craft get [alias] <url>")
 		}
+		if err := manifest.ValidateName(args[0]); err != nil {
+			return fmt.Errorf("invalid alias %q: %w\n  hint: aliases must be lowercase alphanumeric with hyphens (e.g. 'my-skills')", args[0], err)
+		}
 		parsed, err := resolve.ParseDepURL(args[1])
 		if err != nil {
 			return fmt.Errorf("%w\n  hint: expected format: host/org/repo@v1.0.0, host/org/repo@<sha>, or host/org/repo@branch:<name>", err)
@@ -150,6 +153,16 @@ func runGet(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Check for alias collisions among parsed deps
+	seen := make(map[string]string) // alias → url
+	for _, dep := range activeDeps {
+		if existing, ok := seen[dep.alias]; ok {
+			return fmt.Errorf("alias collision: %q resolves to both %s and %s\n  hint: use 'craft get <alias> <url>' to provide distinct aliases",
+				dep.alias, existing, dep.url)
+		}
+		seen[dep.alias] = dep.url
+	}
+
 	// Add all deps to manifest
 	for _, dep := range activeDeps {
 		m.Dependencies[dep.alias] = dep.url
@@ -194,7 +207,8 @@ func runGet(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Write global manifest and pinfile
+	// Write manifest and pinfile before install (write-ahead).
+	// If install fails, the dep is tracked but not installed — recoverable via `craft install -g`.
 	if err := writeManifestAtomic(manifestPath, m); err != nil {
 		return err
 	}
@@ -205,20 +219,20 @@ func runGet(cmd *cobra.Command, args []string) error {
 	// Resolve agent install targets
 	targetPaths, err := resolveInstallTargets(getTarget)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w\n  note: dependencies were added to the global manifest but installation could not complete\n  hint: run 'craft install -g' to retry, or 'craft remove -g <alias>' to undo", err)
 	}
 
 	// Collect skill files
 	skillFiles, err := collectSkillFiles(fetcher, result)
 	if err != nil {
 		progress.Fail("Fetching failed")
-		return err
+		return fmt.Errorf("%w\n  note: dependencies were added to the global manifest but installation could not complete\n  hint: run 'craft install -g' to retry, or 'craft remove -g <alias>' to undo", err)
 	}
 
 	// Verify integrity
 	if err := verifyIntegrity(result, skillFiles); err != nil {
 		progress.Fail("Integrity check failed")
-		return err
+		return fmt.Errorf("%w\n  note: dependencies were added to the global manifest but installation could not complete\n  hint: run 'craft install -g' to retry, or 'craft remove -g <alias>' to undo", err)
 	}
 
 	// Install to agent directories
@@ -226,7 +240,7 @@ func runGet(cmd *cobra.Command, args []string) error {
 	for _, targetPath := range targetPaths {
 		if err := installlib.Install(targetPath, skillFiles); err != nil {
 			progress.Fail("Installation failed")
-			return fmt.Errorf("installation failed: %w", err)
+			return fmt.Errorf("installation failed: %w\n  note: dependencies were added to the global manifest but installation could not complete\n  hint: run 'craft install -g' to retry, or 'craft remove -g <alias>' to undo", err)
 		}
 	}
 

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -1,0 +1,258 @@
+package cli
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	installlib "github.com/erdemtuna/craft/internal/install"
+	"github.com/erdemtuna/craft/internal/manifest"
+	"github.com/erdemtuna/craft/internal/pinfile"
+	"github.com/erdemtuna/craft/internal/resolve"
+	"github.com/erdemtuna/craft/internal/ui"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+var getDryRun bool
+var getTarget string
+
+var getCmd = &cobra.Command{
+	Use:   "get [alias] <url> [url...]",
+	Short: "Install skills globally",
+	Long: `Install skills from one or more repositories into your AI agent's skill directory.
+
+Skills are tracked in ~/.craft/craft.yaml and pinned in ~/.craft/craft.pin.yaml.
+Use craft list -g, craft update -g, and craft remove -g to manage globally installed skills.
+
+Examples:
+  craft get github.com/alice/skills@v1.0.0
+  craft get myalias github.com/alice/skills@v1.0.0
+  craft get github.com/alice/skills@v1.0.0 github.com/bob/tools@v2.0.0`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: runGet,
+}
+
+func init() {
+	getCmd.Flags().BoolVar(&getDryRun, "dry-run", false, "Show what would be resolved and installed without making changes")
+	getCmd.Flags().StringVar(&getTarget, "target", "", "Override agent auto-detection with a custom install path")
+}
+
+func runGet(cmd *cobra.Command, args []string) error {
+	// Parse arguments: optional alias + one or more URLs
+	type depEntry struct {
+		alias  string
+		url    string
+		parsed *resolve.DepURL
+	}
+
+	var deps []depEntry
+
+	// Detect if first arg is an alias (not a URL)
+	firstIsDep := true
+	if len(args) >= 2 {
+		if _, err := resolve.ParseDepURL(args[0]); err != nil {
+			// First arg is not a valid URL — treat as alias for the second arg
+			firstIsDep = false
+		}
+	}
+
+	if !firstIsDep {
+		// First arg is alias, rest are URLs
+		if len(args) != 2 {
+			return fmt.Errorf("when providing an alias, exactly one URL must follow\n  usage: craft get [alias] <url>")
+		}
+		parsed, err := resolve.ParseDepURL(args[1])
+		if err != nil {
+			return fmt.Errorf("%w\n  hint: expected format: host/org/repo@v1.0.0, host/org/repo@<sha>, or host/org/repo@branch:<name>", err)
+		}
+		deps = append(deps, depEntry{alias: args[0], url: args[1], parsed: parsed})
+	} else {
+		// All args are URLs
+		for _, arg := range args {
+			parsed, err := resolve.ParseDepURL(arg)
+			if err != nil {
+				return fmt.Errorf("%w\n  hint: expected format: host/org/repo@v1.0.0, host/org/repo@<sha>, or host/org/repo@branch:<name>", err)
+			}
+			deps = append(deps, depEntry{alias: parsed.Repo, url: arg, parsed: parsed})
+		}
+	}
+
+	// Load or create global manifest
+	manifestPath, err := GlobalManifestPath()
+	if err != nil {
+		return err
+	}
+	pfPath, err := GlobalPinfilePath()
+	if err != nil {
+		return err
+	}
+
+	m, err := manifest.ParseFile(manifestPath)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("reading global craft.yaml: %w", err)
+		}
+		// Auto-create global manifest
+		if err := ensureGlobalDir(); err != nil {
+			return err
+		}
+		m = &manifest.Manifest{
+			SchemaVersion: 1,
+			Name:          "global",
+			Dependencies:  make(map[string]string),
+		}
+	}
+
+	if m.Dependencies == nil {
+		m.Dependencies = make(map[string]string)
+	}
+
+	// Check for already-installed deps and prompt if different
+	isTTY := term.IsTerminal(int(os.Stdin.Fd()))
+	for i, dep := range deps {
+		existing, ok := m.Dependencies[dep.alias]
+		if !ok {
+			continue
+		}
+		if existing == dep.url {
+			cmd.Printf("%q is already installed at %s — skipping.\n", dep.alias, dep.url)
+			// Mark as skip by clearing URL
+			deps[i].url = ""
+			continue
+		}
+		// Different version — prompt
+		if !isTTY {
+			return fmt.Errorf("%q is already installed at %s (requested %s)\n  hint: use an interactive terminal to confirm updates, or use craft update -g",
+				dep.alias, existing, dep.url)
+		}
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "%q is currently at %s. Update to %s? [y/N]: ", dep.alias, existing, dep.url)
+		scanner := bufio.NewScanner(os.Stdin)
+		if !scanner.Scan() || !strings.HasPrefix(strings.ToLower(strings.TrimSpace(scanner.Text())), "y") {
+			cmd.Printf("Skipping %q.\n", dep.alias)
+			deps[i].url = ""
+			continue
+		}
+	}
+
+	// Filter out skipped deps
+	var activeDeps []depEntry
+	for _, dep := range deps {
+		if dep.url != "" {
+			activeDeps = append(activeDeps, dep)
+		}
+	}
+
+	if len(activeDeps) == 0 {
+		cmd.Println("Nothing to install.")
+		return nil
+	}
+
+	// Add all deps to manifest
+	for _, dep := range activeDeps {
+		m.Dependencies[dep.alias] = dep.url
+		// Warn about non-tagged dependencies
+		if dep.parsed.RefType != resolve.RefTypeTag {
+			cmd.PrintErrln("⚠ Non-tagged dependency: " + dep.url)
+		}
+	}
+
+	// Resolve full tree
+	progress := ui.NewProgress()
+	fetcher, err := newFetcher()
+	if err != nil {
+		return err
+	}
+
+	var existingPinfile *pinfile.Pinfile
+	if pf, err := pinfile.ParseFile(pfPath); err == nil {
+		existingPinfile = pf
+	}
+
+	forceResolve := make(map[string]bool)
+	for _, dep := range activeDeps {
+		forceResolve[dep.url] = true
+	}
+
+	progress.Start("Resolving dependencies...")
+	resolver := resolve.NewResolver(fetcher)
+	result, err := resolver.Resolve(m, resolve.ResolveOptions{
+		ExistingPinfile: existingPinfile,
+		ForceResolve:    forceResolve,
+	})
+	if err != nil {
+		progress.Fail("Resolution failed")
+		return fmt.Errorf("resolution failed: %w", err)
+	}
+	progress.Update(fmt.Sprintf("Resolved %d dependency(ies)", len(result.Resolved)))
+
+	if getDryRun {
+		progress.Done("Dry-run complete")
+		printDryRunSummary(cmd, result, "+")
+		return nil
+	}
+
+	// Write global manifest and pinfile
+	if err := writeManifestAtomic(manifestPath, m); err != nil {
+		return err
+	}
+	if err := writePinfileAtomic(pfPath, result.Pinfile); err != nil {
+		return err
+	}
+
+	// Resolve agent install targets
+	targetPaths, err := resolveInstallTargets(getTarget)
+	if err != nil {
+		return err
+	}
+
+	// Collect skill files
+	skillFiles, err := collectSkillFiles(fetcher, result)
+	if err != nil {
+		progress.Fail("Fetching failed")
+		return err
+	}
+
+	// Verify integrity
+	if err := verifyIntegrity(result, skillFiles); err != nil {
+		progress.Fail("Integrity check failed")
+		return err
+	}
+
+	// Install to agent directories
+	progress.Update("Installing skills...")
+	for _, targetPath := range targetPaths {
+		if err := installlib.Install(targetPath, skillFiles); err != nil {
+			progress.Fail("Installation failed")
+			return fmt.Errorf("installation failed: %w", err)
+		}
+	}
+
+	skillCount := countSkills(result)
+	msg := fmt.Sprintf("Installed %d skill(s) from %d package(s) to %s",
+		skillCount, len(result.Resolved), strings.Join(targetPaths, ", "))
+	progress.Done(msg)
+	if !progress.IsTTY() {
+		cmd.Println(msg)
+	}
+
+	// Print summary for each added dep
+	for _, dep := range activeDeps {
+		var skills []string
+		for _, r := range result.Resolved {
+			if r.Alias == dep.alias {
+				skills = r.Skills
+				break
+			}
+		}
+		if len(skills) > 0 {
+			cmd.Printf("  %s: %s\n", dep.alias, strings.Join(skills, ", "))
+		}
+	}
+
+	printDependencyTree(cmd, m, result)
+
+	return nil
+}

--- a/internal/cli/global.go
+++ b/internal/cli/global.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+)
+
+var globalFlag bool
+
+func init() {
+	rootCmd.PersistentFlags().BoolVarP(&globalFlag, "global", "g", false, "Operate on the global (~/.craft/) skill store")
+}
+
+// GlobalCraftDir returns the path to the global craft directory (~/.craft/).
+func GlobalCraftDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".craft"), nil
+}
+
+// GlobalManifestPath returns the path to the global craft manifest (~/.craft/craft.yaml).
+func GlobalManifestPath() (string, error) {
+	dir, err := GlobalCraftDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "craft.yaml"), nil
+}
+
+// GlobalPinfilePath returns the path to the global craft pinfile (~/.craft/craft.pin.yaml).
+func GlobalPinfilePath() (string, error) {
+	dir, err := GlobalCraftDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "craft.pin.yaml"), nil
+}
+
+func ensureGlobalDir() error {
+	dir, err := GlobalCraftDir()
+	if err != nil {
+		return err
+	}
+	return os.MkdirAll(dir, 0o755)
+}

--- a/internal/cli/global_test.go
+++ b/internal/cli/global_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGlobalCraftDir(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+
+	got, err := GlobalCraftDir()
+	if err != nil {
+		t.Fatalf("GlobalCraftDir: %v", err)
+	}
+
+	want := filepath.Join(home, ".craft")
+	if got != want {
+		t.Errorf("GlobalCraftDir() = %q, want %q", got, want)
+	}
+}
+
+func TestGlobalManifestPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+
+	got, err := GlobalManifestPath()
+	if err != nil {
+		t.Fatalf("GlobalManifestPath: %v", err)
+	}
+
+	want := filepath.Join(home, ".craft", "craft.yaml")
+	if got != want {
+		t.Errorf("GlobalManifestPath() = %q, want %q", got, want)
+	}
+}
+
+func TestGlobalPinfilePath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+
+	got, err := GlobalPinfilePath()
+	if err != nil {
+		t.Fatalf("GlobalPinfilePath: %v", err)
+	}
+
+	want := filepath.Join(home, ".craft", "craft.pin.yaml")
+	if got != want {
+		t.Errorf("GlobalPinfilePath() = %q, want %q", got, want)
+	}
+}
+
+func TestGlobalFlag(t *testing.T) {
+	f := rootCmd.PersistentFlags().Lookup("global")
+	if f == nil {
+		t.Fatal("expected --global flag to be registered on rootCmd")
+	}
+	if f.Shorthand != "g" {
+		t.Errorf("expected shorthand 'g', got %q", f.Shorthand)
+	}
+	if f.DefValue != "false" {
+		t.Errorf("expected default value 'false', got %q", f.DefValue)
+	}
+}

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -41,6 +41,57 @@ func requireManifestAndPinfile() (*manifest.Manifest, *pinfile.Pinfile, error) {
 	return m, pf, nil
 }
 
+func manifestPathForScope() (manifestPath string, pinfilePath string, err error) {
+	if globalFlag {
+		manifestPath, err = GlobalManifestPath()
+		if err != nil {
+			return "", "", err
+		}
+		pinfilePath, err = GlobalPinfilePath()
+		if err != nil {
+			return "", "", err
+		}
+		return manifestPath, pinfilePath, nil
+	}
+
+	root, err := os.Getwd()
+	if err != nil {
+		return "", "", fmt.Errorf("getting working directory: %w", err)
+	}
+	return filepath.Join(root, "craft.yaml"), filepath.Join(root, "craft.pin.yaml"), nil
+}
+
+func requireManifestAndPinfileForScope() (*manifest.Manifest, *pinfile.Pinfile, error) {
+	mPath, pfPath, err := manifestPathForScope()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	m, err := manifest.ParseFile(mPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			if globalFlag {
+				return nil, nil, fmt.Errorf("No global skills installed. Use `craft get` to install skills.")
+			}
+			return nil, nil, fmt.Errorf("craft.yaml not found\n  hint: run `craft init` to create one")
+		}
+		return nil, nil, fmt.Errorf("reading craft.yaml: %w", err)
+	}
+
+	pf, err := pinfile.ParseFile(pfPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			if globalFlag {
+				return nil, nil, fmt.Errorf("No global skills installed. Use `craft get` to install skills.")
+			}
+			return nil, nil, fmt.Errorf("craft.pin.yaml not found\n  hint: run `craft install` to resolve and pin dependencies")
+		}
+		return nil, nil, fmt.Errorf("reading craft.pin.yaml: %w", err)
+	}
+
+	return m, pf, nil
+}
+
 // printDryRunSummary prints what would be resolved without making changes.
 // Used by both install --dry-run and update --dry-run.
 func printDryRunSummary(cmd *cobra.Command, result *resolve.ResolveResult, prefix string) {

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -13,34 +13,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// requireManifestAndPinfile parses both craft.yaml and craft.pin.yaml from the
-// current working directory. It returns a user-friendly error if either file
-// is missing — callers should not proceed without both files.
-func requireManifestAndPinfile() (*manifest.Manifest, *pinfile.Pinfile, error) {
-	root, err := os.Getwd()
-	if err != nil {
-		return nil, nil, fmt.Errorf("getting working directory: %w", err)
-	}
-
-	m, err := manifest.ParseFile(filepath.Join(root, "craft.yaml"))
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, nil, fmt.Errorf("craft.yaml not found\n  hint: run `craft init` to create one")
-		}
-		return nil, nil, fmt.Errorf("reading craft.yaml: %w", err)
-	}
-
-	pf, err := pinfile.ParseFile(filepath.Join(root, "craft.pin.yaml"))
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, nil, fmt.Errorf("craft.pin.yaml not found\n  hint: run `craft install` to resolve and pin dependencies")
-		}
-		return nil, nil, fmt.Errorf("reading craft.pin.yaml: %w", err)
-	}
-
-	return m, pf, nil
-}
-
 func manifestPathForScope() (manifestPath string, pinfilePath string, err error) {
 	if globalFlag {
 		manifestPath, err = GlobalManifestPath()
@@ -71,7 +43,7 @@ func requireManifestAndPinfileForScope() (*manifest.Manifest, *pinfile.Pinfile, 
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			if globalFlag {
-				return nil, nil, fmt.Errorf("No global skills installed. Use `craft get` to install skills.")
+				return nil, nil, fmt.Errorf("no global skills installed\n  hint: use `craft get` to install skills")
 			}
 			return nil, nil, fmt.Errorf("craft.yaml not found\n  hint: run `craft init` to create one")
 		}
@@ -82,7 +54,7 @@ func requireManifestAndPinfileForScope() (*manifest.Manifest, *pinfile.Pinfile, 
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			if globalFlag {
-				return nil, nil, fmt.Errorf("No global skills installed. Use `craft get` to install skills.")
+				return nil, nil, fmt.Errorf("no global skills installed\n  hint: use `craft get` to install skills")
 			}
 			return nil, nil, fmt.Errorf("craft.pin.yaml not found\n  hint: run `craft install` to resolve and pin dependencies")
 		}

--- a/internal/cli/helpers_test.go
+++ b/internal/cli/helpers_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestManifestPathForScope(t *testing.T) {
+	t.Run("project scope", func(t *testing.T) {
+		saved := globalFlag
+		t.Cleanup(func() { globalFlag = saved })
+		globalFlag = false
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mPath, pPath, err := manifestPathForScope()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		wantManifest := filepath.Join(cwd, "craft.yaml")
+		wantPinfile := filepath.Join(cwd, "craft.pin.yaml")
+		if mPath != wantManifest {
+			t.Errorf("manifestPath = %q, want %q", mPath, wantManifest)
+		}
+		if pPath != wantPinfile {
+			t.Errorf("pinfilePath = %q, want %q", pPath, wantPinfile)
+		}
+	})
+
+	t.Run("global scope", func(t *testing.T) {
+		saved := globalFlag
+		t.Cleanup(func() { globalFlag = saved })
+		globalFlag = true
+
+		mPath, pPath, err := manifestPathForScope()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		home, err := os.UserHomeDir()
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantManifest := filepath.Join(home, ".craft", "craft.yaml")
+		wantPinfile := filepath.Join(home, ".craft", "craft.pin.yaml")
+		if mPath != wantManifest {
+			t.Errorf("manifestPath = %q, want %q", mPath, wantManifest)
+		}
+		if pPath != wantPinfile {
+			t.Errorf("pinfilePath = %q, want %q", pPath, wantPinfile)
+		}
+	})
+}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -140,6 +140,10 @@ func runInstallGlobal(cmd *cobra.Command) error {
 }
 
 func runInstallProject(cmd *cobra.Command) error {
+	if installTarget != "" {
+		return fmt.Errorf("--target is not supported for project installs (skills vendor to forge/)\n  hint: use `craft install -g --target %s` for global install to a custom path", installTarget)
+	}
+
 	root, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("getting working directory: %w", err)

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -476,17 +476,18 @@ func ensureGitignore(root, entry string) error {
 	if err != nil {
 		return fmt.Errorf("opening .gitignore: %w", err)
 	}
-	defer f.Close()
 
 	// Add newline before entry if file doesn't end with one
 	if len(content) > 0 && content[len(content)-1] != '\n' {
 		if _, err := f.WriteString("\n"); err != nil {
+			_ = f.Close()
 			return err
 		}
 	}
 	if _, err := f.WriteString(entry + "\n"); err != nil {
+		_ = f.Close()
 		return err
 	}
 
-	return nil
+	return f.Close()
 }

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -27,9 +27,12 @@ var installDryRun bool
 var installCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Install skill dependencies",
-	Long:  "Resolve, pin, and install all dependencies declared in craft.yaml.",
-	Args:  cobra.NoArgs,
-	RunE:  runInstall,
+	Long: `Resolve, pin, and install all dependencies declared in craft.yaml.
+
+In project context: vendors dependencies to the forge/ directory (gitignored).
+With --global/-g: re-installs globally tracked dependencies to agent directories.`,
+	Args: cobra.NoArgs,
+	RunE: runInstall,
 }
 
 func init() {
@@ -38,6 +41,105 @@ func init() {
 }
 
 func runInstall(cmd *cobra.Command, args []string) error {
+	if globalFlag {
+		return runInstallGlobal(cmd)
+	}
+	return runInstallProject(cmd)
+}
+
+func runInstallGlobal(cmd *cobra.Command) error {
+	manifestPath, err := GlobalManifestPath()
+	if err != nil {
+		return err
+	}
+	pfPath, err := GlobalPinfilePath()
+	if err != nil {
+		return err
+	}
+
+	progress := ui.NewProgress()
+
+	m, err := manifest.ParseFile(manifestPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("no global skills installed\n  hint: use `craft get` to install skills")
+		}
+		return fmt.Errorf("reading global craft.yaml: %w", err)
+	}
+
+	if len(m.Dependencies) == 0 {
+		cmd.Println("No global dependencies to install.")
+		return nil
+	}
+
+	var existingPinfile *pinfile.Pinfile
+	if pf, err := pinfile.ParseFile(pfPath); err == nil {
+		existingPinfile = pf
+	}
+
+	fetcher, err := newFetcher()
+	if err != nil {
+		return err
+	}
+
+	progress.Start("Resolving global dependencies...")
+	resolver := resolve.NewResolver(fetcher)
+	result, err := resolver.Resolve(m, resolve.ResolveOptions{
+		ExistingPinfile: existingPinfile,
+	})
+	if err != nil {
+		progress.Fail("Resolution failed")
+		return fmt.Errorf("resolution failed: %w", err)
+	}
+	progress.Update(fmt.Sprintf("Resolved %d dependency(ies)", len(result.Resolved)))
+
+	if installDryRun {
+		progress.Done("Dry-run complete")
+		printDryRunSummary(cmd, result, "+")
+		return nil
+	}
+
+	if err := writePinfileAtomic(pfPath, result.Pinfile); err != nil {
+		return err
+	}
+
+	targetPaths, err := resolveInstallTargets(installTarget)
+	if err != nil {
+		return err
+	}
+
+	skillFiles, err := collectSkillFiles(fetcher, result)
+	if err != nil {
+		progress.Fail("Fetching failed")
+		return err
+	}
+
+	if err := verifyIntegrity(result, skillFiles); err != nil {
+		progress.Fail("Integrity check failed")
+		return err
+	}
+
+	progress.Update("Installing skills...")
+	for _, targetPath := range targetPaths {
+		if err := installlib.Install(targetPath, skillFiles); err != nil {
+			progress.Fail("Installation failed")
+			return fmt.Errorf("installation failed: %w", err)
+		}
+	}
+
+	skillCount := countSkills(result)
+	msg := fmt.Sprintf("Installed %d skill(s) from %d package(s) to %s",
+		skillCount, len(result.Resolved), strings.Join(targetPaths, ", "))
+	progress.Done(msg)
+	if !progress.IsTTY() {
+		cmd.Println(msg)
+	}
+
+	printDependencyTree(cmd, m, result)
+	return nil
+}
+
+func runInstallProject(cmd *cobra.Command) error {
 	root, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("getting working directory: %w", err)
@@ -96,11 +198,8 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Determine install path(s)
-	targetPaths, err := resolveInstallTargets(installTarget)
-	if err != nil {
-		return err
-	}
+	// Vendor dependencies to forge/ directory
+	forgePath := filepath.Join(root, "forge")
 
 	// Collect skill files for installation
 	skillFiles, err := collectSkillFiles(fetcher, result)
@@ -115,18 +214,21 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Install to each target path
-	progress.Update("Installing skills...")
-	for _, targetPath := range targetPaths {
-		if err := installlib.Install(targetPath, skillFiles); err != nil {
-			progress.Fail("Installation failed")
-			return fmt.Errorf("installation failed: %w", err)
-		}
+	// Install to forge/ directory
+	progress.Update("Vendoring skills to forge/...")
+	if err := installlib.Install(forgePath, skillFiles); err != nil {
+		progress.Fail("Vendoring failed")
+		return fmt.Errorf("vendoring failed: %w", err)
+	}
+
+	// Auto-add forge/ to .gitignore
+	if err := ensureGitignore(root, "forge/"); err != nil {
+		cmd.PrintErrf("warning: could not update .gitignore: %v\n", err)
 	}
 
 	skillCount := countSkills(result)
-	msg := fmt.Sprintf("Installed %d skill(s) from %d package(s) to %s",
-		skillCount, len(result.Resolved), strings.Join(targetPaths, ", "))
+	msg := fmt.Sprintf("Vendored %d skill(s) from %d package(s) to forge/",
+		skillCount, len(result.Resolved))
 	progress.Done(msg)
 	if !progress.IsTTY() {
 		cmd.Println(msg)
@@ -350,4 +452,41 @@ func newFetcher() (fetch.GitFetcher, error) {
 		return nil, err
 	}
 	return fetch.NewGoGitFetcher(cache), nil
+}
+
+// ensureGitignore adds an entry to .gitignore if it's not already present.
+func ensureGitignore(root, entry string) error {
+	gitignorePath := filepath.Join(root, ".gitignore")
+
+	content, err := os.ReadFile(gitignorePath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("reading .gitignore: %w", err)
+	}
+
+	// Check if entry already exists
+	lines := strings.Split(string(content), "\n")
+	for _, line := range lines {
+		if strings.TrimSpace(line) == entry {
+			return nil
+		}
+	}
+
+	// Append entry
+	f, err := os.OpenFile(gitignorePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening .gitignore: %w", err)
+	}
+	defer f.Close()
+
+	// Add newline before entry if file doesn't end with one
+	if len(content) > 0 && content[len(content)-1] != '\n' {
+		if _, err := f.WriteString("\n"); err != nil {
+			return err
+		}
+	}
+	if _, err := f.WriteString(entry + "\n"); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -586,6 +586,79 @@ func TestVerifyIntegrity_SkipsMissingPinEntry(t *testing.T) {
 	}
 }
 
+func TestEnsureGitignore(t *testing.T) {
+	t.Run("existing entry", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, ".gitignore")
+		original := ".craft/\nnode_modules/\n"
+		if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := ensureGitignore(dir, ".craft/"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		got, _ := os.ReadFile(path)
+		if string(got) != original {
+			t.Errorf("file should be unchanged, got %q", got)
+		}
+	})
+
+	t.Run("new entry", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, ".gitignore")
+		if err := os.WriteFile(path, []byte("node_modules/\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := ensureGitignore(dir, ".craft/"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		got, _ := os.ReadFile(path)
+		want := "node_modules/\n.craft/\n"
+		if string(got) != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		dir := t.TempDir()
+
+		if err := ensureGitignore(dir, ".craft/"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		got, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+		if err != nil {
+			t.Fatalf("file should have been created: %v", err)
+		}
+		want := ".craft/\n"
+		if string(got) != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("no trailing newline", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, ".gitignore")
+		if err := os.WriteFile(path, []byte("node_modules/"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := ensureGitignore(dir, ".craft/"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		got, _ := os.ReadFile(path)
+		want := "node_modules/\n.craft/\n"
+		if string(got) != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}
+
 func TestVerifyIntegrity_BadDepURL(t *testing.T) {
 	skillFiles := map[string]map[string][]byte{
 		"github.com/org/repo/lint": {"SKILL.md": []byte("content")},

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -25,7 +25,7 @@ func init() {
 }
 
 func runList(cmd *cobra.Command, args []string) error {
-	m, pf, err := requireManifestAndPinfile()
+	m, pf, err := requireManifestAndPinfileForScope()
 	if err != nil {
 		return err
 	}

--- a/internal/cli/outdated.go
+++ b/internal/cli/outdated.go
@@ -21,7 +21,7 @@ var outdatedCmd = &cobra.Command{
 }
 
 func runOutdated(cmd *cobra.Command, args []string) error {
-	m, pf, err := requireManifestAndPinfile()
+	m, pf, err := requireManifestAndPinfileForScope()
 	if err != nil {
 		return err
 	}

--- a/internal/cli/remove.go
+++ b/internal/cli/remove.go
@@ -31,7 +31,7 @@ func init() {
 func runRemove(cmd *cobra.Command, args []string) error {
 	alias := args[0]
 
-	var manifestPath, pfPath string
+	var manifestPath, pfPath, root string
 	var err error
 
 	if globalFlag {
@@ -44,7 +44,7 @@ func runRemove(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	} else {
-		root, err := os.Getwd()
+		root, err = os.Getwd()
 		if err != nil {
 			return fmt.Errorf("getting working directory: %w", err)
 		}
@@ -117,10 +117,7 @@ func runRemove(cmd *cobra.Command, args []string) error {
 				targetPath = []string{removeTarget}
 			} else {
 				// Project: clean from forge/ directory
-				root, err := os.Getwd()
-				if err == nil {
-					targetPath = []string{filepath.Join(root, "forge")}
-				}
+				targetPath = []string{filepath.Join(root, "forge")}
 			}
 			if err != nil {
 				// If we can't determine target, just report what was orphaned

--- a/internal/cli/remove.go
+++ b/internal/cli/remove.go
@@ -31,16 +31,34 @@ func init() {
 func runRemove(cmd *cobra.Command, args []string) error {
 	alias := args[0]
 
-	root, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("getting working directory: %w", err)
+	var manifestPath, pfPath string
+	var err error
+
+	if globalFlag {
+		manifestPath, err = GlobalManifestPath()
+		if err != nil {
+			return err
+		}
+		pfPath, err = GlobalPinfilePath()
+		if err != nil {
+			return err
+		}
+	} else {
+		root, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("getting working directory: %w", err)
+		}
+		manifestPath = filepath.Join(root, "craft.yaml")
+		pfPath = filepath.Join(root, "craft.pin.yaml")
 	}
 
 	// Parse manifest
-	manifestPath := filepath.Join(root, "craft.yaml")
 	m, err := manifest.ParseFile(manifestPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
+			if globalFlag {
+				return fmt.Errorf("no global skills installed\n  hint: use `craft get` to install skills")
+			}
 			return fmt.Errorf("craft.yaml not found\n  hint: run `craft init` to create one")
 		}
 		return fmt.Errorf("reading craft.yaml: %w", err)
@@ -54,7 +72,6 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	}
 
 	// Identify skills from the removed dependency (from pinfile)
-	pfPath := filepath.Join(root, "craft.pin.yaml")
 	pf, pfErr := pinfile.ParseFile(pfPath)
 
 	var removedSkills []string
@@ -91,7 +108,20 @@ func runRemove(cmd *cobra.Command, args []string) error {
 
 		// Clean up orphaned skills from install target
 		if len(orphaned) > 0 {
-			targetPath, err := resolveInstallTargets(removeTarget)
+			var targetPath []string
+			if globalFlag {
+				// Global: clean from agent directories
+				targetPath, err = resolveInstallTargets(removeTarget)
+			} else if removeTarget != "" {
+				// Project with explicit --target: use that path
+				targetPath = []string{removeTarget}
+			} else {
+				// Project: clean from forge/ directory
+				root, err := os.Getwd()
+				if err == nil {
+					targetPath = []string{filepath.Join(root, "forge")}
+				}
+			}
 			if err != nil {
 				// If we can't determine target, just report what was orphaned
 				cmd.Printf("  orphaned skills (manual cleanup needed): %s\n", strings.Join(orphaned, ", "))

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -29,6 +29,7 @@ func init() {
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(treeCmd)
 	rootCmd.AddCommand(outdatedCmd)
+	rootCmd.AddCommand(getCmd)
 }
 
 // Execute runs the root command.

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -17,7 +17,7 @@ var treeCmd = &cobra.Command{
 }
 
 func runTree(cmd *cobra.Command, args []string) error {
-	m, pf, err := requireManifestAndPinfile()
+	m, pf, err := requireManifestAndPinfileForScope()
 	if err != nil {
 		return err
 	}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -39,17 +39,35 @@ func init() {
 }
 
 func runUpdate(cmd *cobra.Command, args []string) error {
-	root, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("getting working directory: %w", err)
+	var root, manifestPath, pfPath string
+	var err error
+
+	if globalFlag {
+		manifestPath, err = GlobalManifestPath()
+		if err != nil {
+			return err
+		}
+		pfPath, err = GlobalPinfilePath()
+		if err != nil {
+			return err
+		}
+	} else {
+		root, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("getting working directory: %w", err)
+		}
+		manifestPath = filepath.Join(root, "craft.yaml")
+		pfPath = filepath.Join(root, "craft.pin.yaml")
 	}
 
 	progress := ui.NewProgress()
 
-	manifestPath := filepath.Join(root, "craft.yaml")
 	m, err := manifest.ParseFile(manifestPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
+			if globalFlag {
+				return fmt.Errorf("no global skills installed\n  hint: use `craft get` to install skills")
+			}
 			return fmt.Errorf("craft.yaml not found\n  hint: run `craft init` to create one")
 		}
 		return fmt.Errorf("reading craft.yaml: %w", err)
@@ -78,7 +96,6 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 	// Load existing pinfile (needed for branch update comparison)
 	var existingPinfile *pinfile.Pinfile
-	pfPath := filepath.Join(root, "craft.pin.yaml")
 	if pf, err := pinfile.ParseFile(pfPath); err == nil {
 		existingPinfile = pf
 	}
@@ -194,28 +211,55 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 	// Install
 	progress.Update("Installing skills...")
-	targetPaths, err := resolveInstallTargets(updateTarget)
-	if err != nil {
-		return err
-	}
-
-	skillFiles, err := collectSkillFiles(fetcher, result)
-	if err != nil {
-		return err
-	}
-
-	for _, targetPath := range targetPaths {
-		if err := installlib.Install(targetPath, skillFiles); err != nil {
-			progress.Fail("Installation failed")
-			return fmt.Errorf("installation failed: %w", err)
+	if globalFlag {
+		// Global: install to agent directories
+		targetPaths, err := resolveInstallTargets(updateTarget)
+		if err != nil {
+			return err
 		}
-	}
 
-	skillCount := countSkills(result)
-	msg := fmt.Sprintf("Updated and installed %d skill(s) to %s", skillCount, strings.Join(targetPaths, ", "))
-	progress.Done(msg)
-	if !progress.IsTTY() {
-		cmd.Println(msg)
+		skillFiles, err := collectSkillFiles(fetcher, result)
+		if err != nil {
+			return err
+		}
+
+		for _, targetPath := range targetPaths {
+			if err := installlib.Install(targetPath, skillFiles); err != nil {
+				progress.Fail("Installation failed")
+				return fmt.Errorf("installation failed: %w", err)
+			}
+		}
+
+		skillCount := countSkills(result)
+		msg := fmt.Sprintf("Updated and installed %d skill(s) to %s", skillCount, strings.Join(targetPaths, ", "))
+		progress.Done(msg)
+		if !progress.IsTTY() {
+			cmd.Println(msg)
+		}
+	} else {
+		// Project: vendor to forge/
+		forgePath := filepath.Join(root, "forge")
+
+		skillFiles, err := collectSkillFiles(fetcher, result)
+		if err != nil {
+			return err
+		}
+
+		if err := installlib.Install(forgePath, skillFiles); err != nil {
+			progress.Fail("Vendoring failed")
+			return fmt.Errorf("vendoring failed: %w", err)
+		}
+
+		if err := ensureGitignore(root, "forge/"); err != nil {
+			cmd.PrintErrf("warning: could not update .gitignore: %v\n", err)
+		}
+
+		skillCount := countSkills(result)
+		msg := fmt.Sprintf("Updated and vendored %d skill(s) to forge/", skillCount)
+		progress.Done(msg)
+		if !progress.IsTTY() {
+			cmd.Println(msg)
+		}
 	}
 
 	// Print dependency tree to stderr

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -238,6 +238,9 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		}
 	} else {
 		// Project: vendor to forge/
+		if updateTarget != "" {
+			return fmt.Errorf("--target is not supported for project updates (skills vendor to forge/)\n  hint: use `craft update -g --target %s` for global update to a custom path", updateTarget)
+		}
 		forgePath := filepath.Join(root, "forge")
 
 		skillFiles, err := collectSkillFiles(fetcher, result)

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -1,9 +1,12 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
+	"github.com/erdemtuna/craft/internal/manifest"
+	"github.com/erdemtuna/craft/internal/pinfile"
 	"github.com/erdemtuna/craft/internal/validate"
 	"github.com/spf13/cobra"
 )
@@ -13,9 +16,13 @@ import (
 var validateCmd = &cobra.Command{
 	Use:   "validate",
 	Short: "Validate a craft package",
-	Long:  "Run all validation checks on the current craft package: schema, skill paths, frontmatter, dependency URLs, pinfile consistency, and name collisions.",
+	Long:  "Run all validation checks on the current craft package: schema, skill paths, frontmatter, dependency URLs, pinfile consistency, and name collisions.\nWith --global/-g: validate the global manifest and pinfile.",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if globalFlag {
+			return runValidateGlobal(cmd)
+		}
+
 		root, err := os.Getwd()
 		if err != nil {
 			return fmt.Errorf("getting working directory: %w", err)
@@ -45,4 +52,42 @@ var validateCmd = &cobra.Command{
 		fmt.Fprintf(os.Stderr, "\n%d validation error(s) found\n", len(result.Errors))
 		return fmt.Errorf("validation failed with %d error(s)", len(result.Errors))
 	},
+}
+
+func runValidateGlobal(cmd *cobra.Command) error {
+	manifestPath, err := GlobalManifestPath()
+	if err != nil {
+		return err
+	}
+
+	m, err := manifest.ParseFile(manifestPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("no global manifest found\n  hint: use `craft get` to install skills")
+		}
+		return fmt.Errorf("reading global craft.yaml: %w", err)
+	}
+
+	errs := manifest.ValidateGlobal(m)
+	if len(errs) == 0 {
+		cmd.Println("✓ Global manifest is valid")
+
+		// Also check pinfile if it exists
+		pfPath, err := GlobalPinfilePath()
+		if err != nil {
+			return err
+		}
+		if _, err := pinfile.ParseFile(pfPath); err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				fmt.Fprintf(os.Stderr, "warning: global pinfile issue: %v\n", err)
+			}
+		}
+		return nil
+	}
+
+	for _, e := range errs {
+		fmt.Fprintf(os.Stderr, "error: %s\n", e.Error())
+	}
+	fmt.Fprintf(os.Stderr, "\n%d validation error(s) found\n", len(errs))
+	return fmt.Errorf("validation failed with %d error(s)", len(errs))
 }

--- a/internal/manifest/validate.go
+++ b/internal/manifest/validate.go
@@ -17,6 +17,24 @@ var depURLPattern = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?
 // Validate checks a parsed Manifest against all schema rules.
 // Returns a slice of all validation errors found (does not stop at first error).
 func Validate(m *Manifest) []error {
+	errs := validateCommon(m)
+
+	// skills must be non-empty
+	if len(m.Skills) == 0 {
+		errs = append(errs, fmt.Errorf("skills: must contain at least one skill path"))
+	}
+
+	return errs
+}
+
+// ValidateGlobal validates a global manifest. Identical to Validate but
+// does not require the skills list to be non-empty.
+func ValidateGlobal(m *Manifest) []error {
+	return validateCommon(m)
+}
+
+// validateCommon runs validation rules shared between project and global manifests.
+func validateCommon(m *Manifest) []error {
 	var errs []error
 
 	// schema_version must be 1
@@ -33,11 +51,6 @@ func Validate(m *Manifest) []error {
 		errs = append(errs, fmt.Errorf("name: %q does not match required format (lowercase alphanumeric with hyphens, e.g. 'my-package')", m.Name))
 	}
 
-	// skills must be non-empty
-	if len(m.Skills) == 0 {
-		errs = append(errs, fmt.Errorf("skills: must contain at least one skill path"))
-	}
-
 	// validate dependency URL format for each entry
 	for alias, url := range m.Dependencies {
 		if !depURLPattern.MatchString(url) {
@@ -50,32 +63,6 @@ func Validate(m *Manifest) []error {
 
 // ValidateName checks if a string is a valid package/skill name.
 // Returns an error describing the issue, or nil if valid.
-// ValidateGlobal validates a global manifest. It is identical to Validate but
-// does not require the skills list to be non-empty.
-func ValidateGlobal(m *Manifest) []error {
-	var errs []error
-
-	if m.SchemaVersion != 1 {
-		errs = append(errs, fmt.Errorf("schema_version: must be 1, got %d", m.SchemaVersion))
-	}
-
-	if m.Name == "" {
-		errs = append(errs, fmt.Errorf("name: required field is missing"))
-	} else if len(m.Name) > 128 {
-		errs = append(errs, fmt.Errorf("name: must be 1–128 characters, got %d", len(m.Name)))
-	} else if !namePattern.MatchString(m.Name) {
-		errs = append(errs, fmt.Errorf("name: %q does not match required format (lowercase alphanumeric with hyphens, e.g. 'my-package')", m.Name))
-	}
-
-	for alias, url := range m.Dependencies {
-		if !depURLPattern.MatchString(url) {
-			errs = append(errs, fmt.Errorf("dependencies[%q]: %q does not match required format (host/org/repo@<ref> where ref is vX.Y.Z, commit SHA, or branch:<name>)", alias, url))
-		}
-	}
-
-	return errs
-}
-
 func ValidateName(name string) error {
 	if name == "" {
 		return fmt.Errorf("name is required")

--- a/internal/manifest/validate.go
+++ b/internal/manifest/validate.go
@@ -50,6 +50,32 @@ func Validate(m *Manifest) []error {
 
 // ValidateName checks if a string is a valid package/skill name.
 // Returns an error describing the issue, or nil if valid.
+// ValidateGlobal validates a global manifest. It is identical to Validate but
+// does not require the skills list to be non-empty.
+func ValidateGlobal(m *Manifest) []error {
+	var errs []error
+
+	if m.SchemaVersion != 1 {
+		errs = append(errs, fmt.Errorf("schema_version: must be 1, got %d", m.SchemaVersion))
+	}
+
+	if m.Name == "" {
+		errs = append(errs, fmt.Errorf("name: required field is missing"))
+	} else if len(m.Name) > 128 {
+		errs = append(errs, fmt.Errorf("name: must be 1–128 characters, got %d", len(m.Name)))
+	} else if !namePattern.MatchString(m.Name) {
+		errs = append(errs, fmt.Errorf("name: %q does not match required format (lowercase alphanumeric with hyphens, e.g. 'my-package')", m.Name))
+	}
+
+	for alias, url := range m.Dependencies {
+		if !depURLPattern.MatchString(url) {
+			errs = append(errs, fmt.Errorf("dependencies[%q]: %q does not match required format (host/org/repo@<ref> where ref is vX.Y.Z, commit SHA, or branch:<name>)", alias, url))
+		}
+	}
+
+	return errs
+}
+
 func ValidateName(name string) error {
 	if name == "" {
 		return fmt.Errorf("name is required")

--- a/internal/manifest/validate_test.go
+++ b/internal/manifest/validate_test.go
@@ -161,6 +161,18 @@ func TestValidateMultipleErrors(t *testing.T) {
 	}
 }
 
+func TestValidateGlobal_EmptySkills(t *testing.T) {
+	m := &Manifest{
+		SchemaVersion: 1,
+		Name:          "global-store",
+		Skills:        []string{},
+	}
+	errs := ValidateGlobal(m)
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors for global manifest with empty skills, got %v", errs)
+	}
+}
+
 func assertContains(t *testing.T, s, substr string) {
 	t.Helper()
 	if !strings.Contains(s, substr) {

--- a/internal/manifest/validate_test.go
+++ b/internal/manifest/validate_test.go
@@ -173,6 +173,72 @@ func TestValidateGlobal_EmptySkills(t *testing.T) {
 	}
 }
 
+func TestValidateGlobal_InvalidSchemaVersion(t *testing.T) {
+	m := &Manifest{
+		SchemaVersion: 2,
+		Name:          "test",
+		Skills:        []string{},
+	}
+	errs := ValidateGlobal(m)
+	if len(errs) != 1 {
+		t.Fatalf("Expected 1 error, got %d: %v", len(errs), errs)
+	}
+	assertContains(t, errs[0].Error(), "schema_version")
+}
+
+func TestValidateGlobal_InvalidName(t *testing.T) {
+	m := &Manifest{
+		SchemaVersion: 1,
+		Name:          "INVALID",
+		Skills:        []string{},
+	}
+	errs := ValidateGlobal(m)
+	if len(errs) != 1 {
+		t.Fatalf("Expected 1 error, got %d: %v", len(errs), errs)
+	}
+	assertContains(t, errs[0].Error(), "name")
+}
+
+func TestValidateGlobal_InvalidDepURL(t *testing.T) {
+	m := &Manifest{
+		SchemaVersion: 1,
+		Name:          "test",
+		Skills:        []string{},
+		Dependencies:  map[string]string{"bad": "not-a-valid-url"},
+	}
+	errs := ValidateGlobal(m)
+	if len(errs) != 1 {
+		t.Fatalf("Expected 1 error, got %d: %v", len(errs), errs)
+	}
+	assertContains(t, errs[0].Error(), "dependencies")
+}
+
+func TestValidateGlobal_MultipleErrors(t *testing.T) {
+	m := &Manifest{
+		SchemaVersion: 2,
+		Name:          "",
+		Skills:        []string{},
+		Dependencies:  map[string]string{"bad": "not-a-valid-url"},
+	}
+	errs := ValidateGlobal(m)
+	if len(errs) < 2 {
+		t.Errorf("Expected at least 2 errors, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestValidateGlobal_ValidWithDeps(t *testing.T) {
+	m := &Manifest{
+		SchemaVersion: 1,
+		Name:          "global",
+		Skills:        []string{},
+		Dependencies:  map[string]string{"dep": "github.com/org/repo@v1.0.0"},
+	}
+	errs := ValidateGlobal(m)
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got %v", errs)
+	}
+}
+
 func assertContains(t *testing.T, s, substr string) {
 	t.Helper()
 	if !strings.Contains(s, substr) {


### PR DESCRIPTION
## Summary

Introduces a consumer-friendly skill installation flow and global skill management for craft.

### Key Changes

**New `craft get` command** — One-command entry point for consumers:
```bash
craft get github.com/alice/skills@v1.0.0
```
Fetches, resolves, verifies, and installs skills directly to agent directories (`~/.claude/skills/`, `~/.copilot/skills/`). Auto-creates global state at `~/.craft/craft.yaml` + `~/.craft/craft.pin.yaml`. Supports multiple URLs, alias derivation, `--dry-run`, and `--target`.

**`--global` / `-g` flag** on existing commands:
- `craft list -g`, `craft tree -g`, `craft outdated -g`, `craft validate -g` — read-only operations on global state
- `craft update -g`, `craft remove -g`, `craft install -g` — mutating operations on global state

**`craft install` → `forge/` vendoring**:
- Project installs now vendor dependencies to `forge/` (gitignored) instead of writing to agent directories
- `forge/` is auto-added to `.gitignore`
- `craft add --install` also vendors to `forge/`

**Global manifest infrastructure**:
- `~/.craft/craft.yaml` + `~/.craft/craft.pin.yaml` for tracking globally installed skills
- `ValidateGlobal()` allows empty Skills for consumer manifests
- Scope-aware helpers for loading manifests from project or global context

### Design Decisions

- **`craft get` vs `craft add -g --install`**: Consumer flow needs a single memorable command
- **`forge/` vs `vendor/`**: Fits the craft/skills domain identity
- **Project vs global separation**: Prevents conflicts between project and global installs
- **Version always required**: No implicit "latest tag" — consistent and predictable

### Files Changed (20 files, ~1500 lines)

- `internal/cli/get.go` — New command
- `internal/cli/global.go` — Flag, path helpers
- `internal/cli/install.go` — Forge vendoring + global install path
- `internal/cli/helpers.go` — Scope-aware manifest loading
- `internal/cli/update.go`, `remove.go`, `list.go`, `tree.go`, `outdated.go`, `validate.go` — `-g` flag support
- `internal/manifest/validate.go` — `ValidateGlobal()`
- `README.md` — Consumer flow docs

### Testing

All 15 packages pass with `go test -race ./...`. Pre-push hooks (lint + tests) pass clean.