### PR TITLE
perf: optimize craft get with repo/tree caching and parallel resolution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-git/go-git/v5 v5.17.0
 	github.com/gofrs/flock v0.13.0
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/sync v0.20.0
 	golang.org/x/term v0.40.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbR
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.47.0 h1:Mx+4dIFzqraBXUugkia1OOvlD6LemFo1ALMHjrXDOhY=
 golang.org/x/net v0.47.0/go.mod h1:/jNxtkgq5yWUGYkaZGqo27cfGZ1c5Nen03aYrrKpVRU=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/fetch/gogit.go
+++ b/internal/fetch/gogit.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-git/go-git/v5"
@@ -24,11 +25,20 @@ type GoGitFetcher struct {
 	cache   *Cache
 	timeout time.Duration
 	offline bool // skip network fetches, use cached data only
+
+	mu        sync.Mutex
+	repoCache map[string]*git.Repository // url → cached repo object
+	treeCache map[string][]string        // "url\x00commit" → cached tree paths
 }
 
 // NewGoGitFetcher creates a GoGitFetcher backed by the given cache.
 func NewGoGitFetcher(cache *Cache) *GoGitFetcher {
-	return &GoGitFetcher{cache: cache, timeout: defaultGitTimeout}
+	return &GoGitFetcher{
+		cache:     cache,
+		timeout:   defaultGitTimeout,
+		repoCache: make(map[string]*git.Repository),
+		treeCache: make(map[string][]string),
+	}
 }
 
 // SetOffline configures the fetcher to skip network operations and use
@@ -104,6 +114,18 @@ func (f *GoGitFetcher) ListTags(url string) ([]string, error) {
 
 // ListTree returns all file paths in the repository tree at the given commit.
 func (f *GoGitFetcher) ListTree(url, commitSHA string) ([]string, error) {
+	// Check tree cache first
+	cacheKey := url + "\x00" + commitSHA
+	f.mu.Lock()
+	if cached, ok := f.treeCache[cacheKey]; ok {
+		f.mu.Unlock()
+		// Return a copy to prevent callers from mutating the cache.
+		result := make([]string, len(cached))
+		copy(result, cached)
+		return result, nil
+	}
+	f.mu.Unlock()
+
 	repo, err := f.ensureRepo(url)
 	if err != nil {
 		return nil, WrapAuthError(fmt.Errorf("listing tree from %s: %w", url, err), url)
@@ -127,6 +149,11 @@ func (f *GoGitFetcher) ListTree(url, commitSHA string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("walking tree: %w", err)
 	}
+
+	// Cache the result
+	f.mu.Lock()
+	f.treeCache[cacheKey] = paths
+	f.mu.Unlock()
 
 	return paths, nil
 }
@@ -178,11 +205,37 @@ func (f *GoGitFetcher) ReadFiles(url, commitSHA string, paths []string) (map[str
 
 // ensureRepo returns a go-git Repository for the given URL, using the cache.
 // On cache miss, clones the repo as a bare clone. On cache hit, fetches
-// latest changes.
+// latest changes. Repo objects are cached in memory so subsequent calls
+// for the same URL skip locking, opening, and fetching.
 func (f *GoGitFetcher) ensureRepo(url string) (*git.Repository, error) {
 	if f.cache == nil {
-		return f.cloneToMemory(url)
+		// Still use repo cache for memory clones to deduplicate
+		// concurrent requests for the same URL.
+		f.mu.Lock()
+		if repo, ok := f.repoCache[url]; ok {
+			f.mu.Unlock()
+			return repo, nil
+		}
+		f.mu.Unlock()
+
+		repo, err := f.cloneToMemory(url)
+		if err != nil {
+			return nil, err
+		}
+
+		f.mu.Lock()
+		f.repoCache[url] = repo
+		f.mu.Unlock()
+		return repo, nil
 	}
+
+	// Fast path: return cached repo object
+	f.mu.Lock()
+	if repo, ok := f.repoCache[url]; ok {
+		f.mu.Unlock()
+		return repo, nil
+	}
+	f.mu.Unlock()
 
 	repoPath := f.cache.RepoPath(url)
 
@@ -200,43 +253,59 @@ func (f *GoGitFetcher) ensureRepo(url string) (*git.Repository, error) {
 		}
 	}()
 
+	// Double-check after acquiring lock (another goroutine may have populated)
+	f.mu.Lock()
+	if repo, ok := f.repoCache[url]; ok {
+		f.mu.Unlock()
+		return repo, nil
+	}
+	f.mu.Unlock()
+
+	var repo *git.Repository
 	if f.cache.Has(url) {
 		// Cache hit — open and fetch
-		repo, err := git.PlainOpen(repoPath)
+		repo, err = git.PlainOpen(repoPath)
 		if err != nil {
 			// Corrupted cache — remove and re-clone
 			_ = os.RemoveAll(repoPath)
-			return f.cloneToCache(url, repoPath)
-		}
-
-		if f.offline {
-			return repo, nil
-		}
-
-		// Fetch latest (best-effort — if offline, use existing)
-		auth := Auth(url)
-		ctx, cancel := context.WithTimeout(context.Background(), f.timeout)
-		defer cancel()
-		err = repo.FetchContext(ctx, &git.FetchOptions{
-			RemoteURL: url,
-			Auth:      auth,
-			Tags:      git.AllTags,
-			Force:     true,
-		})
-		if err != nil && err != git.NoErrAlreadyUpToDate {
-			// Auth failures should propagate — stale cache with bad credentials
-			// likely means the user's token expired, not a network issue
-			if isAuthError(err) {
-				return nil, WrapAuthError(fmt.Errorf("fetching %s: %w", url, err), url)
+			repo, err = f.cloneToCache(url, repoPath)
+			if err != nil {
+				return nil, err
 			}
-			// Network/timeout failures — use existing cached data (offline fallback)
+		} else if !f.offline {
+			// Fetch latest (best-effort — if offline, use existing)
+			auth := Auth(url)
+			ctx, cancel := context.WithTimeout(context.Background(), f.timeout)
+			defer cancel()
+			fetchErr := repo.FetchContext(ctx, &git.FetchOptions{
+				RemoteURL: url,
+				Auth:      auth,
+				Tags:      git.AllTags,
+				Force:     true,
+			})
+			if fetchErr != nil && fetchErr != git.NoErrAlreadyUpToDate {
+				// Auth failures should propagate — stale cache with bad credentials
+				// likely means the user's token expired, not a network issue
+				if isAuthError(fetchErr) {
+					return nil, WrapAuthError(fmt.Errorf("fetching %s: %w", url, fetchErr), url)
+				}
+				// Network/timeout failures — use existing cached data (offline fallback)
+			}
 		}
-
-		return repo, nil
+	} else {
+		// Cache miss — clone
+		repo, err = f.cloneToCache(url, repoPath)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	// Cache miss — clone
-	return f.cloneToCache(url, repoPath)
+	// Cache the repo object for subsequent calls
+	f.mu.Lock()
+	f.repoCache[url] = repo
+	f.mu.Unlock()
+
+	return repo, nil
 }
 
 // cloneToCache performs an atomic bare clone to the cache directory.

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/erdemtuna/craft/internal/fetch"
 	"github.com/erdemtuna/craft/internal/integrity"
@@ -13,6 +14,7 @@ import (
 	"github.com/erdemtuna/craft/internal/pinfile"
 	"github.com/erdemtuna/craft/internal/semver"
 	"github.com/erdemtuna/craft/internal/skill"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -222,14 +224,27 @@ func (r *Resolver) Resolve(m *manifest.Manifest, opts ResolveOptions) (*ResolveR
 		return nil, fmt.Errorf("%s", FormatCycle(cycle))
 	}
 
-	// Phase 4: Resolve commit SHAs, discover skills, compute integrity
+	// Phase 4: Resolve commit SHAs, discover skills, compute integrity.
+	// Each resolveOne call is independent (different dep, read-only opts),
+	// so we parallelize with errgroup for concurrent git operations.
 	var resolved []ResolvedDep
+	var mu sync.Mutex
+	var eg errgroup.Group
 	for _, dep := range selected {
-		full, err := r.resolveOne(dep, opts)
-		if err != nil {
-			return nil, err
-		}
-		resolved = append(resolved, full)
+		dep := dep // capture loop variable
+		eg.Go(func() error {
+			full, err := r.resolveOne(dep, opts)
+			if err != nil {
+				return err
+			}
+			mu.Lock()
+			resolved = append(resolved, full)
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
 	}
 
 	// Sort for determinism


### PR DESCRIPTION
## Summary

Optimizes `craft get` performance with three complementary changes that together yield an estimated **7-10× speedup** for typical multi-dependency workloads.

## Changes

### 1. Repository object caching (`internal/fetch/gogit.go`)
- `GoGitFetcher` now caches `*git.Repository` objects in memory
- Previously, every `ResolveRef`, `ReadFiles`, and `ListTree` call triggered a full `ensureRepo()` cycle: acquire file lock → open repo → git fetch → return → release lock
- For a single dependency, this happened **7-9 times**; now it happens **once**
- Includes double-checked locking for thread safety and memory clone deduplication

### 2. ListTree result caching (`internal/fetch/gogit.go`)
- `ListTree()` results are cached by `(url, commitSHA)` key
- Eliminates the redundant tree walk between resolution phase (integrity computation) and install phase (file collection)
- Returns defensive copies to prevent caller mutation of cached data

### 3. Parallel dependency resolution (`internal/resolve/resolver.go`)
- Phase 4 `resolveOne()` loop now uses `errgroup.Group` for concurrent execution
- Each `resolveOne()` call is independent (different dep, read-only options, no shared mutable state)
- Per-repo file locks in the fetcher layer protect against concurrent cache corruption
- Added `golang.org/x/sync` dependency

## Performance Impact

| Metric | Before | After |
|--------|--------|-------|
| `ensureRepo()` calls per dep | 7-9 (each with lock+open+fetch) | 1 |
| Dep resolution | Sequential | Parallel via errgroup |
| ListTree per dep | 2× (resolution + install) | 1× (cached) |
| **Estimated speedup (5 deps)** | baseline | **7-10×** |

## Testing
- All existing tests pass
- Race detector clean (`go test -race ./...`)
- Pre-commit and pre-push hooks pass (vet, lint, tests)