### PR TITLE
fix(resolve): use >= for dependency limit check (#7)

### DIFF
--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -322,7 +322,7 @@ func (r *Resolver) collectDeps(m *manifest.Manifest, parentID, source string, gr
 			continue
 		}
 		visited[identity] = parsed.GitRef()
-		if len(visited) > maxTotalDeps {
+		if len(visited) >= maxTotalDeps {
 			return nil, fmt.Errorf("dependency resolution exceeded maximum of %d total dependencies", maxTotalDeps)
 		}
 


### PR DESCRIPTION
## Summary

Fixes #7. ``len(visited) > maxTotalDeps`` allowed the visited map to reach 201 entries before the error fired (insertion happens before the check). Switching to ``>=`` makes the check trip the moment ``visited`` reaches the documented 200-dep ceiling.

## Change

``internal/resolve/resolver.go:325``, ``>`` → ``>=``.

## Test plan

- [x] ``go build ./...``, clean
- [x] ``go test ./internal/resolve/...``, passes (no existing test exercised the boundary; behavior change is the minimal-impact ``>=`` swap requested in the issue)